### PR TITLE
pkg-config: fix library directory.

### DIFF
--- a/automotive-dlt.pc.in
+++ b/automotive-dlt.pc.in
@@ -17,7 +17,7 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${exec_prefix}/include
 
 Name: DLT


### PR DESCRIPTION
The install destination might be lib64, and a CMake variable
exists that contains this information, CMAKE_INSTALL_LIBDIR.
