### PR TITLE
- Added missing build steps to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,8 +4,15 @@ Alexander Wenzel <Alexander.AW.Wenzel@bmw.de>
 
 Instructions for installing this software
 -----------------------------------------
-This software uses cmake as its build tool. To build and install the
-DLT daemon, follow these steps:
+The following packages need to be installed in order to be able to build and install DLT daemon:
+- cmake
+- zlib
+- dbus
+
+On Ubuntu those dependencies can be installed with the following command:
+- sudo apt-get install cmake zlib1g-dev libdbus-glib-1-dev
+
+To build and install the DLT daemon, follow these steps:
 
 - mkdir build
 - cd build


### PR DESCRIPTION
I've faced with cmake error while generating make files for dlt-daemon.
After searching a bit, I've found out that zlib and dbus packages needed to be installed for default dlt-daemon configuration.
I used Ubuntu 16.04 for build and after I installed the packages cmake generated project successfully.

I think that is good idea to mention required packages in INSTALL notes in order to save the time of someone who will try to build dlt-daemon as I did.