### PR TITLE
Daemon connection handling fixes

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -133,6 +133,8 @@ static int dlt_daemon_client_send_all_multiple(DltDaemon *daemon,
     {
         int ret = 0;
         DLT_DAEMON_SEM_LOCK();
+        DltConnection *next = dlt_connection_get_next(temp->next, type_mask);
+
         ret = dlt_connection_send_multiple(temp,
                                           data1,
                                           size1,
@@ -166,7 +168,7 @@ static int dlt_daemon_client_send_all_multiple(DltDaemon *daemon,
             sent = 1;
         }
 
-        temp = dlt_connection_get_next(temp->next, type_mask);
+        temp = next;
     } /* for */
 
     return sent;

--- a/src/daemon/dlt_daemon_connection.c
+++ b/src/daemon/dlt_daemon_connection.c
@@ -171,6 +171,7 @@ STATIC void dlt_connection_destroy_receiver(DltConnection *con)
     default:
         (void) dlt_receiver_free(con->receiver);
         free(con->receiver);
+        con->receiver = NULL;
         break;
     }
 }
@@ -320,6 +321,9 @@ void dlt_connection_destroy(DltConnection *to_destroy)
 {
     close(to_destroy->receiver->fd);
     dlt_connection_destroy_receiver(to_destroy);
+    /* connection pointer might be in epoll queue and used even after destroying
+     * it. To make sure it is not used anymore, connection type is invalidated */
+    to_destroy->type = DLT_CONNECTION_TYPE_MAX;
     free(to_destroy);
 }
 

--- a/src/daemon/dlt_daemon_connection.c
+++ b/src/daemon/dlt_daemon_connection.c
@@ -47,6 +47,8 @@
 #include "dlt_common.h"
 #include "dlt_gateway.h"
 
+static DltConnectionId connectionId;
+
 /** @brief Generic sending function.
  *
  * We manage different type of connection which have similar send/write
@@ -319,6 +321,7 @@ void *dlt_connection_get_callback(DltConnection *con)
  */
 void dlt_connection_destroy(DltConnection *to_destroy)
 {
+    to_destroy->id = 0;
     close(to_destroy->receiver->fd);
     dlt_connection_destroy_receiver(to_destroy);
     /* connection pointer might be in epoll queue and used even after destroying
@@ -386,6 +389,14 @@ int dlt_connection_create(DltDaemonLocal *daemon_local,
         dlt_log(LOG_CRIT, local_str);
         free(temp);
         return -1;
+    }
+
+    /* We are single threaded no need for protection. */
+    temp->id = connectionId++;
+    if (!temp->id)
+    {
+        /* Skipping 0 */
+        temp->id = connectionId++;
     }
 
     temp->type = type;

--- a/src/daemon/dlt_daemon_connection_types.h
+++ b/src/daemon/dlt_daemon_connection_types.h
@@ -67,10 +67,13 @@ typedef enum {
 #define DLT_CON_MASK_GATEWAY_TIMER      (1 << DLT_CONNECTION_GATEWAY_TIMER)
 #define DLT_CON_MASK_ALL                (0xffff)
 
+typedef unsigned int DltConnectionId;
+
 /* TODO: squash the DltReceiver structure in there
  * and remove any other duplicates of FDs
  */
 typedef struct DltConnection {
+    DltConnectionId id;
     DltReceiver *receiver; /**< Receiver structure for this connection */
     DltConnectionType type; /**< Represents what type of handle is this (like FIFO, serial, client, server) */
     DltConnectionStatus status; /**< Status of connection */

--- a/src/daemon/dlt_daemon_event_handler.c
+++ b/src/daemon/dlt_daemon_event_handler.c
@@ -137,6 +137,10 @@ int dlt_daemon_handle_event(DltEventHandler *pEvent,
             type = con->type;
             fd = con->receiver->fd;
         }
+        else /* connection might have been destroyed in the meanwhile */
+        {
+            continue;
+        }
 
         /* First of all handle epoll error events
          * We only expect EPOLLIN or EPOLLOUT

--- a/src/daemon/dlt_daemon_event_handler.h
+++ b/src/daemon/dlt_daemon_event_handler.h
@@ -39,6 +39,8 @@
 int dlt_daemon_prepare_event_handling(DltEventHandler *);
 int dlt_daemon_handle_event(DltEventHandler *, DltDaemon *, DltDaemonLocal *);
 
+DltConnection *dlt_event_handler_find_connection_by_id(DltEventHandler *,
+                                                       DltConnectionId);
 DltConnection *dlt_event_handler_find_connection(DltEventHandler *,
                                                int);
 


### PR DESCRIPTION
If connection to e.g. DLT Viewer is established/removed very frequently, a memory violation might happen due to a bug in connection handling. 