### PR TITLE
CMake Option: Trigger segmentation fault in case of FATAL log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ option(WITH_DLT_LOGSTORAGE_CTRL_UDEV "PROTOTYPE! Set to ON to build logstorage c
 option(WITH_DLT_LOGSTORAGE_CTRL_PROP "PROTOTYPE! Set to ON to build logstorage control application with proprietary support" OFF)
 option(WITH_DLT_USE_IPv6       "Set to ON for IPv6 support"                                                     ON)
 option(WITH_DLT_KPI        	  "Set to ON to build src/kpi binaries"                                             ON)
+option(WITH_DLT_FATAL_LOG_TRAP "Set to ON to enable DLT_LOG_FATAL trap (trigger segv inside dlt-user library)"  OFF)
+
 # RPM settings
 set( GENIVI_RPM_RELEASE "1")#${DLT_REVISION}")
 set( LICENSE "Mozilla Public License Version 2.0" )
@@ -193,6 +195,10 @@ endif(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
 if(WITH_DLT_LOGSTORAGE_CTRL_PROP)
 	add_definitions( -DDLT_LOGSTORAGE_CTRL_PROP)
 endif(WITH_DLT_LOGSTORAGE_CTRL_PROP)
+
+if (WITH_DLT_FATAL_LOG_TRAP)
+    add_definitions( -DDLT_FATAL_LOG_RESET_ENABLE)
+endif(WITH_DLT_FATAL_LOG_TRAP)
 
 add_subdirectory( doc )
 add_subdirectory( src )

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -63,6 +63,18 @@
 #include "dlt_user_shared_cfg.h"
 #include "dlt_user_cfg.h"
 
+#ifdef DLT_FATAL_LOG_RESET_ENABLE
+#define DLT_LOG_FATAL_RESET_TRAP(LOGLEVEL) \
+    do {                                   \
+        if (LOGLEVEL == DLT_LOG_FATAL) {   \
+            int *p = NULL;                 \
+            *p = 0;                        \
+        }                                  \
+    } while(0)
+#else /* DLT_FATAL_LOG_RESET_ENABLE */
+#define DLT_LOG_FATAL_RESET_TRAP(LOGLEVEL)
+#endif /* DLT_FATAL_LOG_RESET_ENABLE */
+
 static DltUser dlt_user;
 static bool dlt_user_initialised = false;
 static int dlt_user_freeing = 0;
@@ -1420,6 +1432,8 @@ inline DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextDat
 
 DltReturnValue dlt_user_log_write_start_id(DltContext *handle, DltContextData *log, DltLogLevelType loglevel, uint32_t messageid)
 {
+    DLT_LOG_FATAL_RESET_TRAP(loglevel);
+
     // check nullpointer
     if (handle == NULL || log == NULL)
         return DLT_RETURN_WRONG_PARAMETER;


### PR DESCRIPTION
When the user library receives a log with log level DLT_LOG_FATAL it
triggers a segmentation fault to provide information to the developer
via tools like coredump.
This is meant to be used during development only and disabled per default.

Signed-off-by: Christoph Lipka <clipka@jp.adit-jv.com>