### PR TITLE
dlt-client: fix dlt_client_cleanup memory handling

### DIFF
--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -249,6 +249,30 @@ DltReturnValue dlt_client_send_reset_to_factory_default(DltClient *client);
  */
 DltReturnValue dlt_client_setbaudrate(DltClient *client, int baudrate);
 
+/**
+ * Set server ip
+ * @param client pointer to dlt client structure
+ * @param pointer to command line argument
+ * @return negative value if there was an error
+ */
+int dlt_client_set_server_ip(DltClient *client, char *ipaddr);
+
+/**
+ * Set serial device
+ * @client pointer to dlt client structure
+ * @param param pointer to command line argument
+ * @return negative value if there was an error
+ */
+int dlt_client_set_serial_device(DltClient *client, char *serial_device);
+
+/**
+ * Set socket path
+ * @client pointer to dlt client structure
+ * @param param pointer to socket path string
+ * @return negative value if there was an error
+ */
+int dlt_client_set_socket_path(DltClient *client, char *socket_path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -479,7 +479,11 @@ static int dlt_control_init_connection(DltClient *client, void *cb)
     if (dlt_parse_config_param("ControlSocketPath", &client->socketPath) != 0)
     {
         /* Failed to read from conf, copy default */
-        client->socketPath = strdup(DLT_DAEMON_DEFAULT_CTRL_SOCK_PATH);
+        if(dlt_client_set_socket_path(client, DLT_DAEMON_DEFAULT_CTRL_SOCK_PATH) == -1)
+        {
+            pr_error("set socket path didn't succeed\n");
+            return -1;
+        }
     }
     client->mode = DLT_CLIENT_MODE_UNIX;
 

--- a/src/console/dlt-control.c
+++ b/src/console/dlt-control.c
@@ -473,9 +473,12 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            g_dltclient.servIP = argv[index];
+            if(dlt_client_set_server_ip(&g_dltclient, argv[index]) == -1)
+            {
+                pr_error("set server ip didn't succeed\n");
+                return -1;
+            }
         }
-
         if (g_dltclient.servIP == 0)
         {
             /* no hostname selected, show usage and terminate */
@@ -489,9 +492,12 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            g_dltclient.serialDevice = argv[index];
+            if(dlt_client_set_serial_device(&g_dltclient, argv[index]) == -1)
+            {
+                pr_error("set serial device didn't succeed\n");
+                return -1;
+            }
         }
-
         if (g_dltclient.serialDevice == 0)
         {
             /* no serial device name selected, show usage and terminate */

--- a/src/console/dlt-receive.c
+++ b/src/console/dlt-receive.c
@@ -442,7 +442,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.servIP = argv[index];
+            if(dlt_client_set_server_ip(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set server ip didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.servIP == 0)
@@ -458,7 +462,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.serialDevice = argv[index];
+            if(dlt_client_set_serial_device(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set serial device didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.serialDevice == 0)
@@ -469,7 +477,7 @@ int main(int argc, char* argv[])
             return -1;
         }
 
-		dlt_client_setbaudrate(&dltclient,dltdata.bvalue);
+        dlt_client_setbaudrate(&dltclient,dltdata.bvalue);
     }
 
     /* initialise structure to use DLT file */

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -425,8 +425,13 @@ int dlt_gateway_store_connection(DltGateway *gateway,
                       gateway->connections[i].client.sock,
                       DLT_DAEMON_RCVBUFSIZESOCK);
     /* setup DltClient Structure */
-    gateway->connections[i].client.servIP =
-        strdup(gateway->connections[i].ip_address);
+    if(dlt_client_set_server_ip(&gateway->connections[i].client,
+                                    gateway->connections[i].ip_address) == -1)
+    {
+        dlt_log(LOG_ERR,
+                "dlt_client_set_server_ip() failed for gateway connection \n");
+        return -1;
+    }
 
     if (ret != 0)
     {

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -836,3 +836,35 @@ DltReturnValue dlt_client_setbaudrate(DltClient *client, int baudrate)
     return DLT_RETURN_OK;
 }
 
+int dlt_client_set_server_ip(DltClient *client, char *ipaddr)
+{
+    client->servIP = strdup(ipaddr);
+    if (client->servIP == NULL)
+    {
+        dlt_log(LOG_ERR, "ERROR: failed to duplicate server IP\n");
+        return DLT_RETURN_ERROR;
+    }
+    return DLT_RETURN_OK;
+}
+
+int dlt_client_set_serial_device(DltClient *client, char *serial_device)
+{
+    client->serialDevice = strdup(serial_device);
+    if (client->serialDevice == NULL)
+    {
+        dlt_log(LOG_ERR, "ERROR: failed to duplicate serial device\n");
+        return DLT_RETURN_ERROR;
+    }
+    return DLT_RETURN_OK;
+}
+
+int dlt_client_set_socket_path(DltClient *client, char *socket_path)
+{
+    client->socketPath = strdup(socket_path);
+    if (client->socketPath == NULL)
+    {
+        dlt_log(LOG_ERR, "ERROR: failed to duplicate socket path\n");
+        return DLT_RETURN_ERROR;
+    }
+    return DLT_RETURN_OK;
+}

--- a/src/tests/dlt-test-client.c
+++ b/src/tests/dlt-test-client.c
@@ -283,7 +283,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.servIP = argv[index];
+            if(dlt_client_set_server_ip(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set server ip didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.servIP == 0)
@@ -299,7 +303,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.serialDevice = argv[index];
+            if(dlt_client_set_serial_device(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set serial device didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.serialDevice == 0)

--- a/src/tests/dlt-test-multi-process-client.c
+++ b/src/tests/dlt-test-multi-process-client.c
@@ -167,12 +167,20 @@ int init_dlt_connect(DltClient *client, const s_parameters *params, int argc, ch
     if(params->serial > 0)
     {
         client->mode = 1;
-        client->serialDevice = argv[argc - 1];
+        if(dlt_client_set_serial_device(client, argv[argc - 1]) == -1)
+        {
+            fprintf(stderr,"set serial device didn't succeed\n");
+            return -1;
+        }
         dlt_client_setbaudrate(client, params->baudrate);
     }
     else
     {
-        client->servIP = argv[argc - 1];
+        if(dlt_client_set_server_ip(client, argv[argc - 1]) == -1)
+        {
+            fprintf(stderr,"set serial ip didn't succeed\n");
+            return -1;
+        }
     }
     dlt_set_id(id, ECUID);
     return 0;

--- a/src/tests/dlt-test-stress-client.c
+++ b/src/tests/dlt-test-stress-client.c
@@ -304,7 +304,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.servIP = argv[index];
+            if(dlt_client_set_server_ip(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set server ip didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.servIP == 0)
@@ -320,7 +324,11 @@ int main(int argc, char* argv[])
     {
         for (index = optind; index < argc; index++)
         {
-            dltclient.serialDevice = argv[index];
+            if(dlt_client_set_serial_device(&dltclient, argv[index]) == -1)
+            {
+                fprintf(stderr,"set serial device didn't succeed\n");
+                return -1;
+            }
         }
 
         if (dltclient.serialDevice == 0)


### PR DESCRIPTION
Setter function introduced for seting up string parameters which are free'd in dlt_client_cleanup

dlt-receives crashes in case of it is running when daemon is stopped, because in dlt_client_cleanup because of a unnecessary free. Gateway and dlt-receive code is aligned now. 

Signed-off-by: Christoph Lipka <clipka@jp.adit-jv.com>