### PR TITLE
Added Description in dlt-system.conf

### DIFF
--- a/src/system/dlt-system.conf
+++ b/src/system/dlt-system.conf
@@ -24,6 +24,8 @@ ShellEnable = 0
 ########################################################################
 
 # Enable the Syslog Adapter (Default: 0)
+# Enable only when systemd is already running in your system otherwise
+# logs will not come to Client (e.g. dlt_viewer).
 SyslogEnable = 0
 
 # The Context Id of the syslog adapter (Default: SYSL)
@@ -42,6 +44,9 @@ SyslogPort = 47111
 # Dlt-system is started by default as user genivi, see dlt-system.service file.
 # The user genivi must be added to one of the groups 'adm', 'wheel' or
 # 'systemd-journal' to have access to all journal entries.
+# Enable Systemd Journal Adapter only when your system doesn't have systemd.
+# Don't enable both (SyslogEnable = 1 and JournalEnable = 1) together because 
+# it causes bind error (can see on connected client).
 
 # Enable the Systemd Journal Adapter (Default: 0)
 JournalEnable = 0


### PR DESCRIPTION
Added additional information about how to enable syslog feature properly.
If still facing issue while capturing syslogs through client (e.g. dlt_viewer) after following given steps then install listed packages:
build-essential 
build-essential checkinstall
pkg-config libsystemd-journal-dev

Note:
It's is a known issue when you try to capture syslog via dlt_viewer then syslogs wouldn't come in dlt_viewer because of improper configuration (won't route the log to port 47111) of dlt-system.

Signed-off-by: Amber Bhardwaj <amber.bhardwaj10@gmail.com>