### PR TITLE
dlt-adaptor-udp, dlt-adaptor-stdin: implement get of verbosity level from input

### DIFF
--- a/src/adaptor/dlt-adaptor-stdin.c
+++ b/src/adaptor/dlt-adaptor-stdin.c
@@ -91,11 +91,12 @@ int main(int argc, char* argv[])
     char ctid[DLT_ID_SIZE];
     char version[255];
     int timeout = -1;
+    int verbosity = DLT_LOG_INFO;
 
     dlt_set_id(apid, PS_DLT_APP);
     dlt_set_id(ctid, PS_DLT_CONTEXT);
 
-    while ((opt = getopt(argc, argv, "a:c:ht:")) != -1)
+    while ((opt = getopt(argc, argv, "a:c:ht:v:")) != -1)
     {
         switch (opt)
         {
@@ -125,9 +126,49 @@ int main(int argc, char* argv[])
             printf("  -a apid      - Set application id to apid (default: SINA)\n");
             printf("  -c ctid      - Set context id to ctid (default: SINC)\n");
             printf("  -t timeout   - Set timeout when sending messages at exit, in ms (Default: 10000 = 10sec)\n");
+            printf("  -v verbosity level - Set verbosity level (Default: INFO, values: FATAL ERROR WARN INFO DEBUG VERBOSE)\n");
             printf("  -h           - This help\n");
             return 0;
             break;
+        }
+        case 'v':
+        {
+	  if(!strcmp(optarg, "FATAL"))
+          {
+              verbosity = DLT_LOG_FATAL;
+              break;
+          }
+	  else if(!strcmp(optarg, "ERROR"))
+          {
+              verbosity = DLT_LOG_ERROR;
+              break;
+          }
+	  else if(!strcmp(optarg, "WARN"))
+          {
+              verbosity = DLT_LOG_WARN;
+              break;
+          }
+	  else if(!strcmp(optarg, "INFO"))
+          {
+              verbosity = DLT_LOG_INFO;
+              break;
+          }
+	  else if(!strcmp(optarg, "DEBUG"))
+          {
+              verbosity = DLT_LOG_DEBUG;
+              break;
+          }
+	  else if(!strcmp(optarg, "VERBOSE"))
+          {
+              verbosity = DLT_LOG_VERBOSE;
+              break;
+          } else
+          {
+              printf("Wrong verbosity level, setting default to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
+              verbosity = DLT_LOG_INFO;
+              break;
+          }
+          break;
         }
         default: /* '?' */
         {
@@ -148,7 +189,7 @@ int main(int argc, char* argv[])
     {
         if (strcmp(str,"")!=0)
         {
-            DLT_LOG(mycontext, DLT_LOG_INFO, DLT_STRING(str));
+            DLT_LOG(mycontext, verbosity, DLT_STRING(str));
         }
     }
 

--- a/src/adaptor/dlt-adaptor-stdin.c
+++ b/src/adaptor/dlt-adaptor-stdin.c
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
               break;
           } else
           {
-              printf("Wrong verbosity level, setting default to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
+              printf("Wrong verbosity level, setting to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
               verbosity = DLT_LOG_INFO;
               break;
           }

--- a/src/adaptor/dlt-adaptor-udp.c
+++ b/src/adaptor/dlt-adaptor-udp.c
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
               break;
           } else
           {
-              printf("Wrong verbosity level, setting default to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
+              printf("Wrong verbosity level, setting to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
               verbosity = DLT_LOG_INFO;
               break;
           }

--- a/src/adaptor/dlt-adaptor-udp.c
+++ b/src/adaptor/dlt-adaptor-udp.c
@@ -103,13 +103,14 @@ int main(int argc, char* argv[])
     char apid[DLT_ID_SIZE];
     char ctid[DLT_ID_SIZE];
     char version[255];
+    int verbosity = DLT_LOG_INFO;
 
     dlt_set_id(apid, PU_DLT_APP);
     dlt_set_id(ctid, PU_DLT_CONTEXT);
 
     port = RCVPORT;
 
-    while ((opt = getopt(argc, argv, "a:c:hp:")) != -1)
+    while ((opt = getopt(argc, argv, "a:c:hp:v:")) != -1)
     {
         switch (opt)
         {
@@ -134,6 +135,7 @@ int main(int argc, char* argv[])
             printf("-a apid      - Set application id to apid (default: UDPA)\n");
             printf("-c ctid      - Set context id to ctid (default: UDPC)\n");
             printf("-p           - Set receive port number for UDP messages (default: %d) \n", port);
+            printf("-v verbosity level - Set verbosity level (Default: INFO, values: FATAL ERROR WARN INFO DEBUG VERBOSE)\n");
             printf("-h           - This help\n");
             return 0;
             break;
@@ -142,6 +144,45 @@ int main(int argc, char* argv[])
         {
             port = atoi(optarg);
             break;
+        }
+        case 'v':
+        {
+         if(!strcmp(optarg, "FATAL"))
+          {
+              verbosity = DLT_LOG_FATAL;
+              break;
+          }
+         else if(!strcmp(optarg, "ERROR"))
+          {
+              verbosity = DLT_LOG_ERROR;
+              break;
+          }
+         else if(!strcmp(optarg, "WARN"))
+          {
+              verbosity = DLT_LOG_WARN;
+              break;
+          }
+         else if(!strcmp(optarg, "INFO"))
+          {
+              verbosity = DLT_LOG_INFO;
+              break;
+          }
+         else if(!strcmp(optarg, "DEBUG"))
+          {
+              verbosity = DLT_LOG_DEBUG;
+              break;
+          }
+         else if(!strcmp(optarg, "VERBOSE"))
+          {
+              verbosity = DLT_LOG_VERBOSE;
+              break;
+          } else
+          {
+              printf("Wrong verbosity level, setting default to INFO. Accepted values are: FATAL ERROR WARN INFO DEBUG VERBOSE\n");
+              verbosity = DLT_LOG_INFO;
+              break;
+          }
+          break;
         }
         default: /* '?' */
         {
@@ -209,7 +250,7 @@ int main(int argc, char* argv[])
 
         if (bytes_read != 0)
         {
-            DLT_LOG(mycontext, DLT_LOG_INFO, DLT_STRING(recv_data));
+            DLT_LOG(mycontext, verbosity, DLT_STRING(recv_data));
         }
     }
 


### PR DESCRIPTION
    dlt-adaptor-udp, dlt-adaptor-stdin: implement get of verbosity level from input, defaulting to INFO when
    wrong type or none is provided
    
    Signed-off-by: Gianfranco Costamagna <gianfranco.costamagna@abinsula.com>
