### PR TITLE
dlt-system-process-handling: fix warning

### DIFF
--- a/src/system/dlt-system-process-handling.c
+++ b/src/system/dlt-system-process-handling.c
@@ -84,7 +84,7 @@ int daemonize()
     for(i = getdtablesize(); i >= 0; i--)
         close(i);
 
-	int fd = open("/dev/null",O_RDWR);
+    int fd = open("/dev/null",O_RDWR);
     if(fd < 0)
     {
         return -1;


### PR DESCRIPTION
In function ‘daemonize’:
dlt-daemon/src/system/dlt-system-process-handling.c:84:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
     for(i = getdtablesize(); i >= 0; i--)
     ^~~
dlt-daemon/src/system/dlt-system-process-handling.c:87:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
  int fd = open("/dev/null",O_RDWR);
  ^~~

Singed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>