### PR TITLE
dlt_daemon_connection_types: fix builds warnings

### DIFF
--- a/src/daemon/dlt_daemon_connection_types.h
+++ b/src/daemon/dlt_daemon_connection_types.h
@@ -67,7 +67,7 @@ typedef enum {
 #define DLT_CON_MASK_GATEWAY_TIMER      (1 << DLT_CONNECTION_GATEWAY_TIMER)
 #define DLT_CON_MASK_ALL                (0xffff)
 
-typedef unsigned int DltConnectionId;
+typedef uintptr_t DltConnectionId;
 
 /* TODO: squash the DltReceiver structure in there
  * and remove any other duplicates of FDs


### PR DESCRIPTION
/home/gordanmarkus/Workspace/github/dlt-daemon/src/daemon/dlt_daemon_event_handler.c: In function ‘dlt_daemon_handle_event’:
/home/gordanmarkus/Workspace/github/dlt-daemon/src/daemon/dlt_daemon_event_handler.c:131:30: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
         DltConnectionId id = (DltConnectionId)ev->data.ptr;
                              ^
/home/gordanmarkus/Workspace/github/dlt-daemon/src/daemon/dlt_daemon_event_handler.c: In function ‘dlt_connection_check_activate’:
/home/gordanmarkus/Workspace/github/dlt-daemon/src/daemon/dlt_daemon_event_handler.c:381:27: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             ev.data.ptr = (void *)con->id;
                           ^

Signed-of-by: Gordan Markuš <gordan.markus@pelagicore.com>