### PR TITLE
commit a961dba removed README which was necessary to generate asciidocs. Tell cmake to use README.md instead of README

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -30,7 +30,7 @@ if(WITH_DOC)
 		COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/manuals/images
 		COMMAND cp ${CMAKE_SOURCE_DIR}/doc/images/* ${CMAKE_BINARY_DIR}/doc/manuals/images
   		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/INSTALL.html ${CMAKE_SOURCE_DIR}/INSTALL
-  		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/README.html ${CMAKE_SOURCE_DIR}/README
+  		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/README.html ${CMAKE_SOURCE_DIR}/README.md
   		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/ReleaseNotes.html ${CMAKE_SOURCE_DIR}/ReleaseNotes.txt
   		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/dlt_user_manual.html ${CMAKE_SOURCE_DIR}/doc/dlt_user_manual.txt
   		COMMAND asciidoc -a TOC1 -o ${CMAKE_BINARY_DIR}/doc/manuals/dlt_cheatsheet.html ${CMAKE_SOURCE_DIR}/doc/dlt_cheatsheet.txt


### PR DESCRIPTION
As discussed in the mailing list ( http://lists.genivi.org/pipermail/genivi-diagnostic-log-and-trace/2017-May/000492.html ), current compilation with WITH_DOC=ON is broken due to commit a961dba.

This pull request fixes it.
Please let me know if you prefer just receiving patches in the mailing list instead.

Signed-off-by: Pierre N <pierreN@users.noreply.github.com>