### PR TITLE
cmake: fix unit tests compilation with systemd

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -32,7 +32,7 @@ install(TARGETS dlt-daemon
 	COMPONENT base)
 
 if (WITH_DLT_UNIT_TESTS)
-    add_library(dlt_daemon ${dlt_daemon_SRCS})
+    add_library(dlt_daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
     target_link_libraries(dlt_daemon rt ${CMAKE_THREAD_LIBS_INIT})
     install(TARGETS dlt_daemon
     RUNTIME DESTINATION bin


### PR DESCRIPTION
By enabling the WITH_SYSTEMD and WITH_DLT_UNIT_TESTS cmake flags
the build will fail with an error due to a linking issue:

../src/daemon/libdlt_daemon.so: undefined reference to `sd_booted'
collect2: error: ld returned 1 exit status

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>