### PR TITLE
Prevent buffer overflow for mount point path

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -387,7 +387,12 @@ int dlt_logstorage_open_log_file(DltLogStorageConfigData *config,
         return -1;
     }
 
-    sprintf(storage_path, "%s/", dev_path);
+    if(snprintf(storage_path, DLT_OFFLINE_LOGSTORAGE_CONFIG_DIR_PATH_LEN,
+          "%s/", dev_path) >= DLT_OFFLINE_LOGSTORAGE_CONFIG_DIR_PATH_LEN)
+    {
+        dlt_log(LOG_ERR, "Mount point path name too long\n");
+        return -1;
+    }
 
     /* check if there are already files stored */
     if (config->records == NULL)


### PR DESCRIPTION
… in dlt_logstorage_open_log_file.

When using dlt-logstorage-ctrl utility, dlt_logstorage_open_log_file function calls sprintf with raw input (dlt-logstorage-ctrl -p argument) into a buffer on the stack (of size 50).

When the argument length is longer than 50, a buffer overflow happens.
I guess this could hypothetically create a small security issue if the user can choose himself the storage mount point path (depends of DLT usage).

This PR simply uses snprintf instead of sprintf and return an error if the stack variable is not big enough.

Signed-off-by: Pierre N <pierreN@users.noreply.github.com>