### PR TITLE
Data stuck in receiver buffer when dlt_daemon_user_send_log_level() fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ config.h
 include/dlt/dlt_version.h
 .project
 .cproject
-
-
 .settings
+.idea/
+cmake-build-debug/

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2423,14 +2423,10 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
         /* This call also replaces the default values with the values defined for default */
         if (dlt_daemon_user_send_log_level(daemon, context, verbose)==-1)
         {
-            snprintf(local_str,
-                     DLT_DAEMON_TEXTBUFSIZE,
-                     "Can't send current log level as response to %s for (%.4s;%.4s)\n",
+            dlt_vlog(LOG_WARNING, "Can't send current log level as response to %s for (%.4s;%.4s)\n",
                      __func__,
                      context->apid,
                      context->ctid);
-            dlt_log(LOG_WARNING, local_str);
-            return -1;
         }
     }
 


### PR DESCRIPTION
- When dlt_daemon_user_send_log_level() called in
dlt_daemon_process_user_message_register_context() fails -1 was returned
which caused dlt_daemon_process_user_messages() to stop processing
receiver buffer. Remaining data was stuck until new data arrived over
FIFO.

- Make debug output of dlt_daemon_user_send_log_level() more
verbose.

Signed-off-by: Lutz Helwing <lutz_helwing@mentor.com>