### PR TITLE
Fix verbose comment in dlt_user.h

### DIFF
--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -242,7 +242,7 @@ typedef struct
 **************************************************************************************************/
 
 /**
- * Initialize the generation of a DLT log message (intended for usage in non-verbose mode)
+ * Initialize the generation of a DLT log message (intended for usage in verbose mode)
  * This function has to be called first, when an application wants to send a new log messages.
  * Following functions like dlt_user_log_write_string and dlt_user_log_write_finish must only be called,
  * when return value is bigger than zero.
@@ -254,7 +254,7 @@ typedef struct
 DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log, DltLogLevelType loglevel);
 
 /**
- * Initialize the generation of a DLT log message (intended for usage in verbose mode)
+ * Initialize the generation of a DLT log message (intended for usage in non-verbose mode)
  * This function has to be called first, when an application wants to send a new log messages.
  * Following functions like dlt_user_log_write_string and dlt_user_log_write_finish must only be called,
  * when return value is bigger than zero.


### PR DESCRIPTION
The dlt_user_log_write_start* function description mention the verbose/non-verbose option.
According to my understanding verbose means that the code contains the verbose version of message (message as full string).
The non-verbose version uses identifiers in order to reduce the message content and the interpretation of ids will be done by the viewer.

Therefore the comments should be modified to capture this correctly.