### PR TITLE
Prevention for occasional corrupted messages 

### DIFF
--- a/src/daemon/dlt-daemon_cfg.h
+++ b/src/daemon/dlt-daemon_cfg.h
@@ -108,6 +108,9 @@
 /* Default baudrate for serial interface */
 #define DLT_DAEMON_SERIAL_DEFAULT_BAUDRATE 115200
 
+/* configuration of resending attempts when sending to socket was not complete */
+#define DLT_DAEMON_SOCKET_MAXRESEND_ATTEMPTS 5
+
 /************************/
 /* Don't change please! */
 /************************/

--- a/src/daemon/dlt-daemon_cfg.h
+++ b/src/daemon/dlt-daemon_cfg.h
@@ -108,9 +108,6 @@
 /* Default baudrate for serial interface */
 #define DLT_DAEMON_SERIAL_DEFAULT_BAUDRATE 115200
 
-/* configuration of resending attempts when sending to socket was not complete */
-#define DLT_DAEMON_SOCKET_MAXRESEND_ATTEMPTS 5
-
 /************************/
 /* Don't change please! */
 /************************/

--- a/src/daemon/dlt_daemon_socket.c
+++ b/src/daemon/dlt_daemon_socket.c
@@ -172,54 +172,28 @@ int dlt_daemon_socket_send(int sock,void* data1,int size1,void* data2,int size2,
 }
 
 int dlt_daemon_socket_sendreliable(int sock, void* buffer,int  message_size)
-{        
-   int remaining_size = message_size;
-   int data_sent = 0;
-   int errno_send = 0;
-   int resend_ou = 1;
+{
+    int data_sent = 0;
 
-   //try to resend data, if it was not sent for the first time (max retries: DLT_DAEMON_SOCKET_MAXRESEND_ATTEMPTS)
-   //this implementation prevents occasional corrupted messages, when there is e.g. system send buffer full, high system utilization, etc.
-   while (remaining_size > 0 && resend_ou <= DLT_DAEMON_SOCKET_MAXRESEND_ATTEMPTS)
-   {
-       int resend_in = 0;
-       ssize_t ret = 0;
-
-       //repeat due to some temporal issues
-       do
-       {
-            ret = send(sock, buffer + data_sent, remaining_size, 0);
-            if((ret < 0) && (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK))
+    while (data_sent < message_size)
+    {
+        ssize_t ret = send(sock, buffer + data_sent, message_size - data_sent, 0);
+        if (ret < 0)
+        {
+            if (errno==EINTR || errno==EAGAIN || errno==EWOULDBLOCK)
             {
-               snprintf(str,DLT_DAEMON_TEXTBUFSIZE,"dlt_daemon_socket_sendreliable: socket send failed, but it is repeated again [errno: %d]!\n", errno);
-               dlt_log(LOG_WARNING,str);
+                // Temporary error.
+                dlt_vlog(LOG_INFO,"dlt_daemon_socket_sendreliable: socket sending failed [errno: %d], trying again.\n", errno);
             }
-            errno_send  = errno;
-            ++resend_in;
-       } while ((resend_in < DLT_DAEMON_SOCKET_MAXRESEND_ATTEMPTS) && (ret < 0) && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK));
-
-       if (ret < 0)
-       {
-           snprintf(str,DLT_DAEMON_TEXTBUFSIZE,"dlt_daemon_socket_sendreliable: socket send failed [errno: %d]!\n", errno_send);
-           dlt_log(LOG_WARNING,str);
-           return DLT_DAEMON_ERROR_SEND_FAILED;
-       }
-
-       remaining_size -= ret;
-       data_sent += ret;
-
-       //there is data remaining, which should be resent, because corrupted messages may occur
-       if( remaining_size > 0 )
-       {
-           snprintf(str,
-                    DLT_DAEMON_TEXTBUFSIZE,
-                    "dlt_daemon_socket_sendreliable: In RESENDING: attempt number: %d, remaining bytes: %d, errno from send: %d.\n",
-                    resend_ou,remaining_size,errno_send);
-           dlt_log(LOG_INFO,str);
-       }
-       ++resend_ou;
-   }
-   return DLT_DAEMON_ERROR_OK;
+            else
+            {
+                dlt_vlog(LOG_WARNING,"dlt_daemon_socket_sendreliable: socket send failed [errno: %d]!\n", errno);
+                return DLT_DAEMON_ERROR_SEND_FAILED;
+            }
+        }
+        data_sent += ret;
+    }
+    return DLT_DAEMON_ERROR_OK;
 }
 
 int dlt_daemon_socket_get_send_qeue_max_size(int sock)

--- a/src/daemon/dlt_daemon_socket.h
+++ b/src/daemon/dlt_daemon_socket.h
@@ -69,4 +69,13 @@ int dlt_daemon_socket_get_send_qeue_max_size(int sock);
 
 int dlt_daemon_socket_send(int sock,void* data1,int size1,void* data2,int size2,char serialheader);
 
+/**
+ * @brief dlt_daemon_socket_sendreliable - sends data to socket with additional checks and resending functionality - trying to be reliable
+ * @param sock
+ * @param buffer
+ * @param message_size
+ * @return on sucess: DLT_DAEMON_ERROR_OK, on error: DLT_DAEMON_ERROR_SEND_FAILED
+ */
+int dlt_daemon_socket_sendreliable(int sock, void* buffer,int  message_size);
+
 #endif /* DLT_DAEMON_SOCKET_H */


### PR DESCRIPTION
This patch prevents occasional corrupt messages, which occur mostly in situations, where system is highly utilized: e.g. socket send buffer is full (or situation when write function is interrupted).
