### PR TITLE
Reworked dlt_daemon_client_send_all_multiple function

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -3226,7 +3226,7 @@ int dlt_daemon_close_socket(int sock, DltDaemon *daemon, DltDaemonLocal *daemon_
     if((daemon_local == NULL)|| (daemon == NULL))
     {
         dlt_log(LOG_ERR, "dlt_daemon_close_socket: Invalid input parmeters\n");
-        return -1;
+        return DLT_RETURN_ERROR;
     }
 
     /* Closure is done while unregistering has for any connection */
@@ -3246,6 +3246,9 @@ int dlt_daemon_close_socket(int sock, DltDaemon *daemon, DltDaemonLocal *daemon_
         // In the offline trace AND in the socket stream.
         if(daemon_local->flags.yvalue[0] == 0)
             dlt_daemon_change_state(daemon,DLT_DAEMON_STATE_BUFFER);
+
+        //send connection info to buffer, if there are not any clients available
+        dlt_daemon_control_message_connection_info(DLT_DAEMON_SEND_TO_ALL,daemon,daemon_local,DLT_CONNECTION_STATUS_DISCONNECTED,"",verbose);
     }
 
     if (daemon_local->flags.vflag)
@@ -3254,9 +3257,7 @@ int dlt_daemon_close_socket(int sock, DltDaemon *daemon, DltDaemonLocal *daemon_
         dlt_log(LOG_INFO, str);
     }
 
-    dlt_daemon_control_message_connection_info(DLT_DAEMON_SEND_TO_ALL,daemon,daemon_local,DLT_CONNECTION_STATUS_DISCONNECTED,"",verbose);
-
-    return 0;
+    return DLT_RETURN_OK;
 }
 
 /**

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -274,7 +274,7 @@ int dlt_daemon_client_send(int sock,DltDaemon *daemon,DltDaemonLocal *daemon_loc
 	{
         if (((daemon->mode == DLT_USER_MODE_INTERNAL) || (daemon->mode == DLT_USER_MODE_BOTH))
 							&& daemon_local->flags.offlineTraceDirectory[0])
-		{
+        {
             if (dlt_offline_trace_write(&(daemon_local->offlineTrace),storage_header,storage_header_size,data1,size1,data2,size2))
 			{
 				static int error_dlt_offline_trace_write_failed = 0;
@@ -306,7 +306,7 @@ int dlt_daemon_client_send(int sock,DltDaemon *daemon,DltDaemonLocal *daemon_loc
     if ((daemon->mode == DLT_USER_MODE_EXTERNAL) || (daemon->mode == DLT_USER_MODE_BOTH))
 	{
         if ((sock == DLT_DAEMON_SEND_FORCE) || (daemon->state == DLT_DAEMON_STATE_SEND_DIRECT))
-		{
+        {
             sent = dlt_daemon_client_send_all_multiple(daemon,
                                                        daemon_local,
                                                        data1,
@@ -316,9 +316,9 @@ int dlt_daemon_client_send(int sock,DltDaemon *daemon,DltDaemonLocal *daemon_loc
                                                        verbose);
 
             if ((sock == DLT_DAEMON_SEND_FORCE) && sent != DLT_DAEMON_ERROR_OK)
-			{
-				return DLT_DAEMON_ERROR_SEND_FAILED;
-			}
+            {
+                return DLT_DAEMON_ERROR_SEND_FAILED;
+            }
             //this handles some unexpected errors
             if (sock != DLT_DAEMON_SEND_FORCE && sent == DLT_DAEMON_ERROR_UNKNOWN && daemon->state == DLT_DAEMON_STATE_SEND_DIRECT)
             {

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -246,7 +246,7 @@ int dlt_daemon_client_send_all(DltDaemon *daemon,
 
 int dlt_daemon_client_send(int sock,DltDaemon *daemon,DltDaemonLocal *daemon_local,void* storage_header,int storage_header_size,void* data1,int size1,void* data2,int size2,int verbose)
 {
-	int sent,ret;
+    int sent = DLT_RETURN_OK,ret;
 
     if (sock!=DLT_DAEMON_SEND_TO_ALL && sock!=DLT_DAEMON_SEND_FORCE)
     {
@@ -329,11 +329,17 @@ int dlt_daemon_client_send(int sock,DltDaemon *daemon,DltDaemonLocal *daemon_loc
                                                        size2,
                                                        verbose);
 
-			if((sock==DLT_DAEMON_SEND_FORCE) && !sent)
+            if((sock == DLT_DAEMON_SEND_FORCE) && sent != DLT_RETURN_OK)
 			{
 				return DLT_DAEMON_ERROR_SEND_FAILED;
 			}
-		}
+            //this handles some unawaited errors
+            if (sent == DLT_DAEMON_ERROR_UNKNOWN && sock != DLT_DAEMON_SEND_FORCE && daemon->state == DLT_DAEMON_STATE_SEND_DIRECT)
+            {
+                return DLT_DAEMON_ERROR_SEND_FAILED;
+            }
+        }
+        
     }
 
     /* Message was not sent to client, so store it in client ringbuffer */


### PR DESCRIPTION
Fixing: for loop is not running through all items, 
reworked dlt_daemon_client_send_all_multiple, connection info sent only when the number of connections is 0.