### PR TITLE
Update dlt-system-filetransfer.c

### DIFF
--- a/src/system/dlt-system-filetransfer.c
+++ b/src/system/dlt-system-filetransfer.c
@@ -746,6 +746,7 @@ void start_filetransfer(DltSystemConfiguration *conf)
     DLT_LOG(dltsystem, DLT_LOG_DEBUG, DLT_STRING("dlt-system-filetransfer, start."));
     static pthread_attr_t t_attr;
     static pthread_t pt;
+	pthread_attr_init(&t_attr);
     pthread_create(&pt, &t_attr, (void *)filetransfer_thread, conf);
     threads.threads[threads.count++] = pt;
 }


### PR DESCRIPTION
Initialize the variable t_attr before being used by pthread_create.