### PR TITLE
Update dlt-system-watchdog.c

### DIFF
--- a/src/system/dlt-system-watchdog.c
+++ b/src/system/dlt-system-watchdog.c
@@ -181,6 +181,8 @@ void start_systemd_watchdog(DltSystemConfiguration *conf)
 
 	static pthread_attr_t t_attr;
 	static pthread_t pt;
+	
+	pthread_attr_init(&t_attr);
 
 	if (pthread_create(&pt, &t_attr, (void *)watchdog_thread, conf) == 0)
 	{


### PR DESCRIPTION
Initialize the variable t_attr before being used by pthread_create.