### PR TITLE
Update dlt-system-processes.c

### DIFF
--- a/src/system/dlt-system-processes.c
+++ b/src/system/dlt-system-processes.c
@@ -171,6 +171,7 @@ void start_logprocess(DltSystemConfiguration *conf)
 			DLT_STRING("dlt-system-processes, starting process log."));
 	static pthread_attr_t t_attr;
 	static pthread_t pt;
+	pthread_attr_init(&t_attr);
 	pthread_create(&pt, &t_attr, (void *)logprocess_thread, conf);
 	threads.threads[threads.count++] = pt;
 }


### PR DESCRIPTION
Initialize the variable t_attr before being used by pthread_create.