### PR TITLE
Update in dlt_daemon_client.c

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1747,7 +1747,10 @@ void dlt_daemon_control_set_default_log_level(int sock, DltDaemon *daemon, DltDa
     if (/*(req->log_level>=0) &&*/
             (req->log_level<=DLT_LOG_VERBOSE))
     {
-        daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
+        if(daemon_local->flags.enforceContextLLAndTS)
+    		daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+    	else
+        	daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
 
         /* Send Update to all contexts using the default log level */
         dlt_daemon_user_send_default_update(daemon, verbose);
@@ -1819,7 +1822,10 @@ void dlt_daemon_control_set_default_trace_status(int sock, DltDaemon *daemon, Dl
     if ((req->log_level==DLT_TRACE_STATUS_OFF) ||
             (req->log_level==DLT_TRACE_STATUS_ON))
     {
-        daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
+        if(daemon_local->flags.enforceContextLLAndTS)
+    		daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
+    	else
+    		daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
 
         /* Send Update to all contexts using the default trace status */
         dlt_daemon_user_send_default_update(daemon, verbose);

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -82,6 +82,20 @@
 /** Global text output buffer, mainly used for creation of error/warning strings */
 static char str[DLT_DAEMON_TEXTBUFSIZE];
 
+/** Inline function to calculate/set the requested log level or traces status
+ *  with default log level or trace status when "ForceContextLogLevelAndTraceStatus"
+ *  is enabled and set to 1 in dlt.conf file.
+ *
+ * @param request_log The requested log level (or) trace status
+ * @param context_log The default log level (or) trace status
+ *
+ * @return The log level if requested log level is lower or equal to ContextLogLevel
+*/
+static inline int8_t getStatus(uint8_t request_log, int context_log)
+{
+    return (request_log <= context_log)? request_log : context_log;
+}
+
 /** @brief Sends up to 2 messages to all the clients.
  *
  * Runs through the client list and sends the messages to them. If the message
@@ -1634,7 +1648,7 @@ void dlt_daemon_control_set_log_level(int sock, DltDaemon *daemon, DltDaemonLoca
 
     req = (DltServiceSetLogLevel*) (msg->databuffer);
     if (daemon_local->flags.enforceContextLLAndTS)
-        req->log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+        req->log_level = getStatus(req->log_level, daemon_local->flags.contextLogLevel);
 
     dlt_set_id(apid, req->apid);
     dlt_set_id(ctid, req->ctid);
@@ -1706,9 +1720,9 @@ void dlt_daemon_control_set_trace_status(int sock, DltDaemon *daemon, DltDaemonL
     {
         old_trace_status = context->trace_status;
 	if (daemon_local->flags.enforceContextLLAndTS)
-	    context->trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
+	    context->trace_status = getStatus(req->log_level, daemon_local->flags.contextTraceStatus);
 	else
-            context->trace_status = req->log_level;   /* No endianess conversion necessary */
+	    context->trace_status = req->log_level;   /* No endianess conversion necessary */
 
         if ((context->user_handle >= DLT_FD_MINIMUM ) &&
                 (dlt_daemon_user_send_log_level(daemon, context, verbose)==0))
@@ -1753,7 +1767,7 @@ void dlt_daemon_control_set_default_log_level(int sock, DltDaemon *daemon, DltDa
             (req->log_level<=DLT_LOG_VERBOSE))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-	    daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+	    daemon->default_log_level = getStatus(req->log_level, daemon_local->flags.contextLogLevel);
 	else
 	    daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
 
@@ -1792,10 +1806,10 @@ void dlt_daemon_control_set_all_log_level(int sock, DltDaemon *daemon, DltDaemon
     if ((req != NULL) && (req->log_level <= DLT_LOG_VERBOSE))
     {
 	if (daemon_local->flags.enforceContextLLAndTS)
-            loglevel = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+            loglevel = getStatus(req->log_level, daemon_local->flags.contextLogLevel);
 	else
-    	    loglevel = req->log_level; /* No endianess conversion necessary */
-	    
+	    loglevel = req->log_level; /* No endianess conversion necessary */
+
         /* Send Update to all contexts using the new log level */
         dlt_daemon_user_send_all_update(daemon, loglevel, verbose);
 
@@ -1832,7 +1846,7 @@ void dlt_daemon_control_set_default_trace_status(int sock, DltDaemon *daemon, Dl
             (req->log_level==DLT_TRACE_STATUS_ON))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-	    daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
+	    daemon->default_trace_status = getStatus(req->log_level, daemon_local->flags.contextTraceStatus);
     	else
 	    daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1753,9 +1753,9 @@ void dlt_daemon_control_set_default_log_level(int sock, DltDaemon *daemon, DltDa
             (req->log_level<=DLT_LOG_VERBOSE))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-            daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
-	else
-            daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
+			daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+		else
+			daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
 
         /* Send Update to all contexts using the default log level */
         dlt_daemon_user_send_default_update(daemon, verbose);
@@ -1832,9 +1832,9 @@ void dlt_daemon_control_set_default_trace_status(int sock, DltDaemon *daemon, Dl
             (req->log_level==DLT_TRACE_STATUS_ON))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-    	    daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
+			daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
     	else
-    	    daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
+			daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
 
         /* Send Update to all contexts using the default trace status */
         dlt_daemon_user_send_default_update(daemon, verbose);

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1753,9 +1753,9 @@ void dlt_daemon_control_set_default_log_level(int sock, DltDaemon *daemon, DltDa
             (req->log_level<=DLT_LOG_VERBOSE))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-			daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
-		else
-			daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
+	    daemon->default_log_level = req->log_level <= daemon_local->flags.contextLogLevel ? req->log_level:daemon_local->flags.contextLogLevel;
+	else
+	    daemon->default_log_level = req->log_level; /* No endianess conversion necessary */
 
         /* Send Update to all contexts using the default log level */
         dlt_daemon_user_send_default_update(daemon, verbose);
@@ -1832,9 +1832,9 @@ void dlt_daemon_control_set_default_trace_status(int sock, DltDaemon *daemon, Dl
             (req->log_level==DLT_TRACE_STATUS_ON))
     {
         if (daemon_local->flags.enforceContextLLAndTS)
-			daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
+	    daemon->default_trace_status = req->log_level <= daemon_local->flags.contextTraceStatus ? req->log_level:daemon_local->flags.contextTraceStatus;
     	else
-			daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
+	    daemon->default_trace_status = req->log_level; /* No endianess conversion necessary*/
 
         /* Send Update to all contexts using the default trace status */
         dlt_daemon_user_send_default_update(daemon, verbose);


### PR DESCRIPTION
Even Forcing log level and trace status of context to not exceed "ContextLogLevel" and "ContextTraceStatus" in dlt.conf file with ForceContextLogLevelAndTraceStatus = 1, the default log level is being overwritten with high value than expected by client(DLT_Viewer when default trace data request is sent ) and by dlt-control application on usage of (dlt-control -d loglevel IP_ADDRESS)

With provided patch/changes in place, when ForceContextLogLevelAndTraceStatus  is enabled the requested log level is checked with ContextLogLevel and if it satisfied the daemon default loglevel gets updated.