### PR TITLE
dlt-daemon: Fix repeated output of marker message

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -3046,7 +3046,10 @@ int dlt_daemon_process_user_message_marker(DltDaemon *daemon,
     }
 
     memset(&userctxt, 0, len);
-    if (dlt_receiver_check_and_get(rec, &userctxt, len, 1) < 0)
+    if (dlt_receiver_check_and_get(rec,
+                                   &userctxt,
+                                   len,
+                                   DLT_RCV_SKIP_HEADER | DLT_RCV_REMOVE) < 0)
     {
         /* Not enough bytes received */
         return -1;


### PR DESCRIPTION
Marker message had been continued to output
if application called dlt_log_marker() due to missing
byte removing processing against marker message.
Therefore the byte removing for marker message processing is added.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>