### PR TITLE
dlt-daemon: Fix infinite loop on set log level using wildcards

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1584,7 +1584,7 @@ void dlt_daemon_find_multiple_context_and_send(int sock, DltDaemon *daemon, DltD
 {
     PRINT_FUNCTION_VERBOSE(verbose);
 
-    int8_t count = 0;
+    int count = 0;
     DltDaemonContext *context = NULL;
     char src_str[DLT_ID_SIZE +1] = {0};
     int8_t ret = 0;


### PR DESCRIPTION
dlt-daemon entered to infinite loop when set log level request with
wildcards came from dlt-control due to variable size.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>