### PR TITLE
dlt-daemon: Lower log level of logs not to output unintentional warning

### DIFF
--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -402,8 +402,7 @@ DltDaemonApplication* dlt_daemon_application_add(DltDaemon *daemon, char *apid, 
         if ( dlt_user_handle < 0 )
         {
             int prio = (errno == ENOENT) ? LOG_INFO : LOG_WARNING;
-            snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "open() failed to %s, errno=%d (%s)!\n",filename,errno,strerror(errno)); /* errno 2: ENOENT - No such file or directory */
-            dlt_log(prio, str);
+            dlt_vlog(prio, "open() failed to %s, errno=%d (%s)!\n", filename, errno, strerror(errno));
         } /* if */
 
         /* check if file file descriptor was already used, and make it invalid if it is reused */
@@ -508,8 +507,7 @@ int dlt_daemon_applications_load(DltDaemon *daemon, const char *filename, int ve
 
     if (fd == NULL)
     {
-        snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "DLT runtime-application load, cannot open file %s: %s\n", filename, strerror(errno));
-        dlt_log(LOG_INFO, str);
+        dlt_vlog(LOG_INFO, "DLT runtime-application load, cannot open file %s: %s\n", filename, strerror(errno));
 
         return -1;
     }
@@ -884,8 +882,7 @@ int dlt_daemon_contexts_load(DltDaemon *daemon, const char *filename, int verbos
 
     if (fd == NULL)
     {
-        snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "DLT runtime-context load, cannot open file %s: %s\n", filename, strerror(errno));
-        dlt_log(LOG_INFO, str);
+        dlt_vlog(LOG_INFO, "DLT runtime-context load, cannot open file %s: %s\n", filename, strerror(errno));
 
         return -1;
     }
@@ -1104,8 +1101,7 @@ int dlt_daemon_configuration_load(DltDaemon *daemon, const char *filename, int v
     }
     else
     {
-        snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE,"Cannot open configuration file: %s\n",filename);
-        dlt_log(LOG_INFO, str);
+        dlt_vlog(LOG_INFO, "Cannot open configuration file: %s\n",filename);
     }
 
     return 0;

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -401,8 +401,9 @@ DltDaemonApplication* dlt_daemon_application_add(DltDaemon *daemon, char *apid, 
         dlt_user_handle = open(filename, O_WRONLY|O_NONBLOCK);
         if ( dlt_user_handle < 0 )
         {
+            int prio = (errno == ENOENT) ? LOG_INFO : LOG_WARNING;
             snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "open() failed to %s, errno=%d (%s)!\n",filename,errno,strerror(errno)); /* errno 2: ENOENT - No such file or directory */
-            dlt_log(LOG_WARNING, str);
+            dlt_log(prio, str);
         } /* if */
 
         /* check if file file descriptor was already used, and make it invalid if it is reused */
@@ -508,7 +509,7 @@ int dlt_daemon_applications_load(DltDaemon *daemon, const char *filename, int ve
     if (fd == NULL)
     {
         snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "DLT runtime-application load, cannot open file %s: %s\n", filename, strerror(errno));
-        dlt_log(LOG_WARNING, str);
+        dlt_log(LOG_INFO, str);
 
         return -1;
     }
@@ -884,7 +885,7 @@ int dlt_daemon_contexts_load(DltDaemon *daemon, const char *filename, int verbos
     if (fd == NULL)
     {
         snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "DLT runtime-context load, cannot open file %s: %s\n", filename, strerror(errno));
-        dlt_log(LOG_WARNING, str);
+        dlt_log(LOG_INFO, str);
 
         return -1;
     }
@@ -1104,7 +1105,7 @@ int dlt_daemon_configuration_load(DltDaemon *daemon, const char *filename, int v
     else
     {
         snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE,"Cannot open configuration file: %s\n",filename);
-        dlt_log(LOG_WARNING, str);
+        dlt_log(LOG_INFO, str);
     }
 
     return 0;


### PR DESCRIPTION
Change log level of several logs from WARNING to INFO.
1. User FIFO cannot be opened because the FIFO does not exist
   --> This case can happen if DLT user app is one-shot
2. Runtime configuration file (dlt-runtime-application.cfg / dlt-runtime-context.cfg)
   cannot be opened
   --> This case can happen in normal use case.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>