### PR TITLE
dlt-daemon: Continue to send log level / connection status even if er…

### DIFF
--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -1296,7 +1296,7 @@ void dlt_daemon_user_send_default_update(DltDaemon *daemon, int verbose)
                 {
                     if (dlt_daemon_user_send_log_level(daemon, context, verbose)==-1)
                     {
-                        return;
+                        dlt_vlog(LOG_WARNING, "Cannot update default of %.4s:%.4s\n", context->apid, context->ctid);
                     }
                 }
             }
@@ -1326,7 +1326,7 @@ void dlt_daemon_user_send_all_log_level_update(DltDaemon *daemon, int8_t log_lev
                 context->log_level = log_level;
                 if (dlt_daemon_user_send_log_level(daemon, context, verbose) == -1)
                 {
-                    return;
+                    dlt_vlog(LOG_WARNING, "Cannot send log level %.4s:%.4s -> %i\n", context->apid, context->ctid, context->log_level);
                 }
             }
         }
@@ -1387,7 +1387,7 @@ void dlt_daemon_user_send_all_log_state(DltDaemon *daemon, int verbose)
             {
                 if (dlt_daemon_user_send_log_state(daemon, app, verbose)==-1)
                 {
-                    return;
+                    dlt_vlog(LOG_WARNING, "Cannot send log state to Apid: %.4s, PID: %d\n",app->apid, app->pid);
                 }
             }
         }


### PR DESCRIPTION
…ror occurs

In previous, there was possibility that application could not get
notification from dlt-daemon due to wrong error handling.
(e.g.)
  1. App1, App2 and App3 register App/Context
  2. App2 crashes without unregistering App/Context
  3. Change default log level from DLT Viewer
     --> App1 can receive new default log level from dlt-daemon but App3 cannot.

This patch makes processing non-stop even if error occurs in below cases:
- While updating log level of all registered apps
- While updating default log level/ default trace status
- While updating connection status between dlt-daemon and dlt-client

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>