### PR TITLE
dlt-daemon: Not output Context un-/registration DLT message by default

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2522,7 +2522,10 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
                  context->ctid,
                  context->apid,
                  context->context_description);
-        dlt_daemon_log_internal(daemon, daemon_local, local_str, verbose);
+        if (verbose)
+        {
+            dlt_daemon_log_internal(daemon, daemon_local, local_str, verbose);
+        }
         dlt_log(LOG_DEBUG, local_str);
     }
 
@@ -2752,10 +2755,13 @@ int dlt_daemon_process_user_message_unregister_context(DltDaemon *daemon,
                      "Unregistered CtID '%.4s' for ApID '%.4s'\n",
                      userctxt.ctid,
                      userctxt.apid);
-            dlt_daemon_log_internal(daemon,
-                                    daemon_local,
-                                    local_str,
-                                    verbose);
+            if (verbose)
+            {
+                dlt_daemon_log_internal(daemon,
+                                        daemon_local,
+                                        local_str,
+                                        verbose);
+            }
             dlt_log(LOG_DEBUG, local_str);
         }
     }


### PR DESCRIPTION
This patch changes Context un-/registration message not to output DLT
by default for the purpose of reducing trace messages.
Actually dlt-daemon already sends almost same meaning control message
which can show Context un-/registration([get_log_info] and [unregister_context]).
These are duplicate message and should be suppressed in normal case.

Only if "Verbose = 1" is set in dlt.conf, the messages are output as same as before.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>