### PR TITLE
dlt-daemon: Avoid to output duplicated application registration message

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2267,6 +2267,8 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
     uint32_t len = sizeof(DltUserControlMsgRegisterApplication);
     int to_remove = 0;
     DltDaemonApplication *application = NULL;
+    DltDaemonApplication *old_application = NULL;
+    pid_t old_pid = 0;
     char local_str[DLT_DAEMON_TEXTBUFSIZE] = { '\0' };
     char description[DLT_DAEMON_DESCSIZE + 1] = { '\0' };
     DltUserControlMsgRegisterApplication userapp;
@@ -2332,6 +2334,11 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
         return -1;
     }
 
+    old_application = dlt_daemon_application_find(daemon, userapp.apid, verbose);
+    if (old_application != NULL)
+    {
+        old_pid = old_application->pid;
+    }
     application = dlt_daemon_application_add(daemon,
                                              userapp.apid,
                                              userapp.pid,
@@ -2354,17 +2361,20 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
     }
     else
     {
-        snprintf(local_str,
-                 DLT_DAEMON_TEXTBUFSIZE,
-                 "ApplicationID '%.4s' registered for PID %d, Description=%s\n",
-                 application->apid,
-                 application->pid,
-                 application->application_description);
-        dlt_daemon_log_internal(daemon,
-                                daemon_local,
-                                local_str,
-                                daemon_local->flags.vflag);
-        dlt_log(LOG_DEBUG, local_str);
+        if (old_pid != application->pid)
+        {
+            snprintf(local_str,
+                     DLT_DAEMON_TEXTBUFSIZE,
+                     "ApplicationID '%.4s' registered for PID %d, Description=%s\n",
+                     application->apid,
+                     application->pid,
+                     application->application_description);
+            dlt_daemon_log_internal(daemon,
+                                    daemon_local,
+                                    local_str,
+                                    daemon_local->flags.vflag);
+            dlt_log(LOG_DEBUG, local_str);
+        }
     }
 
     return 0;

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -357,7 +357,7 @@ DltDaemonApplication* dlt_daemon_application_add(DltDaemon *daemon, char *apid, 
 
         new_application = 1;
 
-    } else if (pid != application->pid) {
+    } else if ((pid != application->pid) && (application->pid != 0)) {
 
         snprintf(str,DLT_DAEMON_COMMON_TEXTBUFSIZE, "Duplicate registration of ApplicationID: '%.4s'; registering from PID %d, existing from PID %d\n",apid, pid, application->pid);
         dlt_log(LOG_WARNING, str);


### PR DESCRIPTION
If application tries to send application registration request before
dlt-daemon startup, the request is sent twice as below:
1. Buffered request in user library buffer
2. New request when user app succeeds to attach to dlt-daemon

In previous, dlt-daemon had been output the registration messages
2 times even though these messages were come from same application.
This duplicated output is avoided by this change.

Warning message in case of dlt-runtime-context.cfg exists
is also avoided. This file is created when Control message: "Store Config"
is used. This is not irregular case.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>