### PR TITLE
dlt-daemon: Fix no state transition to BUFFER state

### DIFF
--- a/src/daemon/dlt_daemon_event_handler.c
+++ b/src/daemon/dlt_daemon_event_handler.c
@@ -156,7 +156,7 @@ int dlt_daemon_handle_event(DltEventHandler *pEvent,
             {
                 /* To transition to BUFFER state if this is final TCP client connection,
                  * call dedicated function. this function also calls
-                 * dlt_event_handler_unregister_connection() insize the function.
+                 * dlt_event_handler_unregister_connection() inside the function.
                  */
                 dlt_daemon_close_socket(fd, daemon, daemon_local, 0);
             }

--- a/src/daemon/dlt_daemon_event_handler.c
+++ b/src/daemon/dlt_daemon_event_handler.c
@@ -151,9 +151,21 @@ int dlt_daemon_handle_event(DltEventHandler *pEvent,
         {
             /* epoll reports an error, we need to clean-up the concerned event
              */
-            dlt_event_handler_unregister_connection(pEvent,
-                                                   daemon_local,
-                                                   fd);
+
+            if (type == DLT_CONNECTION_CLIENT_MSG_TCP)
+            {
+                /* To transition to BUFFER state if this is final TCP client connection,
+                 * call dedicated function. this function also calls
+                 * dlt_event_handler_unregister_connection() insize the function.
+                 */
+                dlt_daemon_close_socket(fd, daemon, daemon_local, 0);
+            }
+            else
+            {
+                dlt_event_handler_unregister_connection(pEvent,
+                                                        daemon_local,
+                                                        fd);
+            }
             continue;
         }
 


### PR DESCRIPTION
When epoll detected error for TCP client connection, no state transition
had been happened. (Only the file descriptor had been closed)
To prevent this, dedicated close function is called according to connection type.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>