### PR TITLE
Update dlt_user.c

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1436,11 +1436,11 @@ DltReturnValue dlt_forward_msg(void *msgdata,size_t size)
         {
             DLT_SEM_LOCK();
 			
-			if(ret == DLT_RETURN_PIPE_ERROR)
+            if (ret == DLT_RETURN_PIPE_ERROR)
             {
-            	/* handle not open or pipe error */
-            	   close(dlt_user.dlt_log_handle);
-            	   dlt_user.dlt_log_handle = -1;
+                /* handle not open or pipe error */
+                   close(dlt_user.dlt_log_handle);
+                   dlt_user.dlt_log_handle = -1;
             }
 
             if (dlt_buffer_push3(&(dlt_user.startup_buffer),
@@ -3712,12 +3712,11 @@ DltReturnValue dlt_user_log_send_log(DltContextData *log, int mtype)
         if ((ret!=DLT_RETURN_OK) || (dlt_user.appID[0] == '\0'))
         {
             DLT_SEM_LOCK();
-			
-			if(ret == DLT_RETURN_PIPE_ERROR)
+            if (ret == DLT_RETURN_PIPE_ERROR)
             {
-            	/* handle not open or pipe error */
-            	   close(dlt_user.dlt_log_handle);
-            	   dlt_user.dlt_log_handle = -1;
+                /* handle not open or pipe error */
+                   close(dlt_user.dlt_log_handle);
+                   dlt_user.dlt_log_handle = -1;
             }
 
             if (dlt_buffer_push3(&(dlt_user.startup_buffer),

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1435,6 +1435,13 @@ DltReturnValue dlt_forward_msg(void *msgdata,size_t size)
         if (ret < DLT_RETURN_OK)
         {
             DLT_SEM_LOCK();
+			
+			if(ret == DLT_RETURN_PIPE_ERROR)
+            {
+            	/* handle not open or pipe error */
+            	   close(dlt_user.dlt_log_handle);
+            	   dlt_user.dlt_log_handle = -1;
+            }
 
             if (dlt_buffer_push3(&(dlt_user.startup_buffer),
                                 (unsigned char *)&(userheader), sizeof(DltUserHeader),
@@ -3705,6 +3712,13 @@ DltReturnValue dlt_user_log_send_log(DltContextData *log, int mtype)
         if ((ret!=DLT_RETURN_OK) || (dlt_user.appID[0] == '\0'))
         {
             DLT_SEM_LOCK();
+			
+			if(ret == DLT_RETURN_PIPE_ERROR)
+            {
+            	/* handle not open or pipe error */
+            	   close(dlt_user.dlt_log_handle);
+            	   dlt_user.dlt_log_handle = -1;
+            }
 
             if (dlt_buffer_push3(&(dlt_user.startup_buffer),
                                 (unsigned char *)&(userheader), sizeof(DltUserHeader),


### PR DESCRIPTION
In dlt_user_log_send_log and dlt_forward_msg API's when writing the data to DLT PIPE is not successful in scenario which returns "DLT_RETURN_PIPE_ERROR"(Non availability of dlt pipe post termination of DLT DAEMON) it ideally starts stores the data in internal buffer, and close the dlt user handle, which is quiet appropriate.
The scenario were dlt application fails in writing data to dlt pipe returns DLT_RETURN_PIPE_ERROR and case were application buffer is full, the return value DLT_RETURN_PIPE_ERROR is over written to "DLT_RETURN_BUFFER_FULL" were dlt user handle will not be reset to -1, it till holds the former data which causes undefined behavior of dlt application(One behavior would be which calls dlt_user_queue_resend and internally allocates memory for segmented data and tries to free it at dlt_user_trace_network_segmented_thread which is not intended behavior, instead return silently when FIFO is not available)