### PR TITLE
dlt-daemon: fixed linked-list element remove

### DIFF
--- a/src/daemon/dlt_daemon_event_handler.c
+++ b/src/daemon/dlt_daemon_event_handler.c
@@ -254,23 +254,25 @@ STATIC int dlt_daemon_remove_connection(DltEventHandler *ev,
     {
         return DLT_RETURN_ERROR;
     }
-    DltConnection **curr = &ev->connections;
+
+    DltConnection *curr = ev->connections;
 
     /* Find the address where to_remove value is registered */
-    while (*curr && (*curr != to_remove))
+    while (curr && (curr->next != to_remove))
     {
-        curr = &(*curr)->next;
+        curr = curr->next;
     }
 
-    if (!*curr)
+    if (!curr)
     {
         /* Must not be possible as we check for existence before */
         dlt_log(LOG_CRIT, "Connection not found for removal.\n");
         return -1;
     }
-
-    /* Replace the content of the address by the next value */
-    *curr = (*curr)->next;
+    else
+    {
+        curr->next = curr->next->next;
+    }
 
     /* Now we can destroy our pointer */
     dlt_connection_destroy(to_remove);


### PR DESCRIPTION
Issue:
Dlt-daemon sometimes crashes due to incorrect connection removal.
The dlt_daemon_remove_connection function does not remove an item from the linked list, it just frees the memory used by the list item. This item is still used by daemon.
Fix:
Added correct removing of linked-list element.