### PR TITLE
Fix gcc 8 build

### DIFF
--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -210,7 +210,7 @@ int dlt_parse_config_param(char *config_id, char **config_data)
                         {
                             *(config_data) = (char*)
                                     calloc(DLT_DAEMON_FLAG_MAX, sizeof(char));
-                            strncpy(*config_data,
+                            memcpy(*config_data,
                                 value,
                                 DLT_DAEMON_FLAG_MAX-1);
                         }

--- a/src/console/logstorage/dlt-logstorage-common.c
+++ b/src/console/logstorage/dlt-logstorage-common.c
@@ -310,7 +310,7 @@ static DltControlMsgBody *prepare_message_body(DltControlMsgBody **body,
     /* mount_point is DLT_MOUNT_PATH_MAX + 1 long,
      * and the memory is already zeroed.
      */
-    strncpy(serv->mount_point, path, DLT_MOUNT_PATH_MAX);
+    strncpy(serv->mount_point, path, DLT_MOUNT_PATH_MAX-1);
 
     pr_verbose("Body is now ready.\n");
 

--- a/systemd/3rdparty/sd-daemon.c
+++ b/systemd/3rdparty/sd-daemon.c
@@ -450,7 +450,7 @@ _sd_export_ int sd_notify(int unset_environment, const char *state) {
 
         memset(&sockaddr, 0, sizeof(sockaddr));
         sockaddr.sa.sa_family = AF_UNIX;
-        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path));
+        strncpy(sockaddr.un.sun_path, e, sizeof(sockaddr.un.sun_path)-1);
 
         if (sockaddr.un.sun_path[0] == '@')
                 sockaddr.un.sun_path[0] = 0;


### PR DESCRIPTION
This PR is providing 3 fixes that allow us to build dlt-daemon with GCC 8 when the stringop-truncation warning is treated as an error.