### PR TITLE
build: Remove unused include that was breaking build

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -47,9 +47,6 @@
 #endif
 #include <sys/stat.h>
 #include <sys/time.h>
-#ifdef linux
-#include <linux/stat.h>
-#endif
 
 #include "dlt_types.h"
 #include "dlt-daemon.h"

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -46,9 +46,6 @@
 #endif
 #include <sys/stat.h>
 #include <sys/time.h>
-#ifdef linux
-#include <linux/stat.h>
-#endif
 
 #ifdef DLT_SYSTEMD_WATCHDOG_ENABLE
 #include <systemd/sd-daemon.h>

--- a/src/daemon/dlt_daemon_socket.c
+++ b/src/daemon/dlt_daemon_socket.c
@@ -49,9 +49,6 @@
 #endif
 #include <sys/stat.h>
 #include <sys/time.h>
-#ifdef linux
-#include <linux/stat.h>
-#endif
 
 #include "dlt_types.h"
 #include "dlt-daemon.h"


### PR DESCRIPTION
glibc 2.28 install new headers, accessible via `sys/stat.h` that
redefine things defined on `linux/stat.h`. As dlt-daemon doesn't appear
to use anything from `linux/stat.h`, just remove it.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>