### PR TITLE
Fflush stdout in the intenal logger

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -2051,6 +2051,7 @@ DltReturnValue dlt_log(int prio, char *s)
         case DLT_LOG_TO_CONSOLE:
             /* log to stdout */
             printf(sFormatString, (unsigned int)sTimeSpec.tv_sec, (unsigned int)(sTimeSpec.tv_nsec/1000), getpid(), asSeverity[prio], s);
+            fflush(stdout);
             break;
         case DLT_LOG_TO_SYSLOG:
             /* log to syslog */


### PR DESCRIPTION
Hi there!

We're spawning dlt-daemon within an application piping stdout/err/in and waiting for certain output (for testing) but it blocks because by default pipes are buffered. It'd be nice to see the logs right away.