### PR TITLE
Gateway Improvements

### DIFF
--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -296,9 +296,9 @@ int dlt_client_set_socket_path(DltClient *client, char *socket_path);
  * Parse GET_LOG_INFO response text
  * @param resp      GET_LOG_INFO response
  * @param resp_text response text represented by ASCII
- * @return 0 on success, -1 otherwise
+ * @return Value from DltReturnValue enum
  */
-int dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
+DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
                                             char *resp_text);
 
 /**

--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -180,6 +180,18 @@ DltReturnValue dlt_client_send_log_level(DltClient *client, char *apid, char *ct
  */
 int dlt_client_get_log_info(DltClient *client);
 /**
+ * Send an request to get default log level to the dlt daemon
+ * @param client pointer to dlt client structure
+ * @return negative value if there was an error
+ */
+DltReturnValue dlt_client_get_default_log_level(DltClient *client);
+/**
+ * Send an request to get software version to the dlt daemon
+ * @param client pointer to dlt client structure
+ * @return negative value if there was an error
+ */
+int dlt_client_get_software_version(DltClient *client);
+/**
  * Initialise get log info structure
  * @param void
  * @return void
@@ -280,6 +292,21 @@ int dlt_client_set_serial_device(DltClient *client, char *serial_device);
  */
 int dlt_client_set_socket_path(DltClient *client, char *socket_path);
 
+/**
+ * Parse GET_LOG_INFO response text
+ * @param resp      GET_LOG_INFO response
+ * @param resp_text response text represented by ASCII
+ * @return 0 on success, -1 otherwise
+ */
+int dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
+                                            char *resp_text);
+
+/**
+ * Free memory allocated for get log info message
+ * @param resp response
+ * @return 0 on success, -1 otherwise
+ */
+int dlt_client_cleanup_get_log_info(DltServiceGetLogInfoResponse *resp);
 #ifdef __cplusplus
 }
 #endif

--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -210,7 +210,6 @@ enum {
 /**
  * Definitions for GET_LOG_INFO
  */
-#define DLT_RECEIVE_TEXTBUFSIZE 1024  /* Size of buffer for text output */
 #define DLT_GET_LOG_INFO_HEADER 18     /*Get log info header size in response text */
 #define GET_LOG_INFO_LENGTH 13
 #define SERVICE_OPT_LENGTH 3
@@ -359,6 +358,16 @@ enum {
  * Maximal IPC path len
  */
 #define DLT_IPC_PATH_MAX 100
+
+/**
+ * Maximal receiver buffer size for application messages
+ */
+#define DLT_RECEIVE_BUFSIZE 65535
+
+/**
+ * Maximal line length
+ */
+#define DLT_LINE_LEN 1024
 
 /**
  * Provision to test static function
@@ -1488,6 +1497,8 @@ extern "C"
      *
      * @param rp        char
      * @param rp_count  int
+     * @param wp        char
+     * @param length        int
      */
     void dlt_getloginfo_conv_ascii_to_id(char *rp, int *rp_count, char *wp, int len);
 

--- a/include/dlt/dlt_protocol.h
+++ b/include/dlt/dlt_protocol.h
@@ -173,37 +173,54 @@
 /*
  * Definitions of DLT services.
  */
-#define DLT_SERVICE_ID_SET_LOG_LEVEL                   0x01 /**< Service ID: Set log level */
-#define DLT_SERVICE_ID_SET_TRACE_STATUS                0x02 /**< Service ID: Set trace status */
-#define DLT_SERVICE_ID_GET_LOG_INFO                    0x03 /**< Service ID: Get log info */
-#define DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL           0x04 /**< Service ID: Get dafault log level */
-#define DLT_SERVICE_ID_STORE_CONFIG                    0x05 /**< Service ID: Store configuration */
-#define DLT_SERVICE_ID_RESET_TO_FACTORY_DEFAULT        0x06 /**< Service ID: Reset to factory defaults */
-#define DLT_SERVICE_ID_SET_COM_INTERFACE_STATUS        0x07 /**< Service ID: Set communication interface status */
-#define DLT_SERVICE_ID_SET_COM_INTERFACE_MAX_BANDWIDTH 0x08 /**< Service ID: Set communication interface maximum bandwidth */
-#define DLT_SERVICE_ID_SET_VERBOSE_MODE                0x09 /**< Service ID: Set verbose mode */
-#define DLT_SERVICE_ID_SET_MESSAGE_FILTERING           0x0A /**< Service ID: Set message filtering */
-#define DLT_SERVICE_ID_SET_TIMING_PACKETS              0x0B /**< Service ID: Set timing packets */
-#define DLT_SERVICE_ID_GET_LOCAL_TIME                  0x0C /**< Service ID: Get local time */
-#define DLT_SERVICE_ID_USE_ECU_ID                      0x0D /**< Service ID: Use ECU id */
-#define DLT_SERVICE_ID_USE_SESSION_ID                  0x0E /**< Service ID: Use session id */
-#define DLT_SERVICE_ID_USE_TIMESTAMP                   0x0F /**< Service ID: Use timestamp */
-#define DLT_SERVICE_ID_USE_EXTENDED_HEADER             0x10 /**< Service ID: Use extended header */
-#define DLT_SERVICE_ID_SET_DEFAULT_LOG_LEVEL           0x11 /**< Service ID: Set default log level */
-#define DLT_SERVICE_ID_SET_DEFAULT_TRACE_STATUS        0x12 /**< Service ID: Set default trace status */
-#define DLT_SERVICE_ID_GET_SOFTWARE_VERSION            0x13 /**< Service ID: Get software version */
-#define DLT_SERVICE_ID_MESSAGE_BUFFER_OVERFLOW         0x14 /**< Service ID: Message buffer overflow */
-#define DLT_SERVICE_ID_LAST_ENTRY                      0x15 /**< Service ID: Last entry to avoid any further modifications in dependent code */
-#define DLT_SERVICE_ID_UNREGISTER_CONTEXT             0xf01 /**< Service ID: Message unregister context */
-#define DLT_SERVICE_ID_CONNECTION_INFO                0xf02 /**< Service ID: Message connection info */
-#define DLT_SERVICE_ID_TIMEZONE                       0xf03 /**< Service ID: Timezone */
-#define DLT_SERVICE_ID_MARKER                         0xf04 /**< Service ID: Marker */
-#define DLT_SERVICE_ID_OFFLINE_LOGSTORAGE             0xf05 /**< Service ID: Offline log storage */
-#define DLT_SERVICE_ID_PASSIVE_NODE_CONNECT           0xf0E /**< Service ID: (Dis)Connect passive Node */
-#define DLT_SERVICE_ID_PASSIVE_NODE_CONNECTION_STATUS 0xf0F /**< Service ID: Passive Node status information */
-#define DLT_SERVICE_ID_SET_ALL_LOG_LEVEL              0xf10 /**< Service ID: set all log level */
-#define DLT_SERVICE_ID_SET_ALL_TRACE_STATUS           0xf11 /**< Service ID: Set all trace status */
-#define DLT_SERVICE_ID_CALLSW_CINJECTION              0xFFF /**< Service ID: Message Injection (minimal ID) */
+#define DLT_SERVICE_ID_CALLSW_CINJECTION 0xFFF
+
+enum dlt_services {
+    DLT_SERVICE_ID = 0x00,
+    DLT_SERVICE_ID_SET_LOG_LEVEL = 0x01,
+    DLT_SERVICE_ID_SET_TRACE_STATUS = 0x02,
+    DLT_SERVICE_ID_GET_LOG_INFO = 0x03,
+    DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL = 0x04,
+    DLT_SERVICE_ID_STORE_CONFIG = 0x05,
+    DLT_SERVICE_ID_RESET_TO_FACTORY_DEFAULT = 0x06,
+    DLT_SERVICE_ID_SET_COM_INTERFACE_STATUS = 0x07,
+    DLT_SERVICE_ID_SET_COM_INTERFACE_MAX_BANDWIDTH = 0x08,
+    DLT_SERVICE_ID_SET_VERBOSE_MODE = 0x09,
+    DLT_SERVICE_ID_SET_MESSAGE_FILTERING = 0x0A,
+    DLT_SERVICE_ID_SET_TIMING_PACKETS = 0x0B,
+    DLT_SERVICE_ID_GET_LOCAL_TIME = 0x0C,
+    DLT_SERVICE_ID_USE_ECU_ID = 0x0D,
+    DLT_SERVICE_ID_USE_SESSION_ID = 0x0E,
+    DLT_SERVICE_ID_USE_TIMESTAMP = 0x0F,
+    DLT_SERVICE_ID_USE_EXTENDED_HEADER = 0x10,
+    DLT_SERVICE_ID_SET_DEFAULT_LOG_LEVEL = 0x11,
+    DLT_SERVICE_ID_SET_DEFAULT_TRACE_STATUS = 0x12,
+    DLT_SERVICE_ID_GET_SOFTWARE_VERSION = 0x13,
+    DLT_SERVICE_ID_MESSAGE_BUFFER_OVERFLOW = 0x14,
+    DLT_SERVICE_ID_LAST_ENTRY
+};
+
+enum dlt_user_services {
+    DLT_USER_SERVICE_ID = 0xF00,
+    DLT_SERVICE_ID_UNREGISTER_CONTEXT = 0xF01,
+    DLT_SERVICE_ID_CONNECTION_INFO = 0xF02,
+    DLT_SERVICE_ID_TIMEZONE = 0xF03,
+    DLT_SERVICE_ID_MARKER = 0xF04,
+    DLT_SERVICE_ID_OFFLINE_LOGSTORAGE = 0xF05,
+    DLT_SERVICE_ID_SET_FILTER_LEVEL = 0xF06,
+    DLT_SERVICE_ID_GET_FILTER_STATUS = 0xF07,
+    DLT_SERVICE_ID_PASSIVE_NODE_CONNECT = 0xF08,
+    DLT_SERVICE_ID_PASSIVE_NODE_CONNECTION_STATUS = 0xF09,
+    DLT_SERVICE_ID_SET_ALL_LOG_LEVEL = 0xF0A,
+    DLT_SERVICE_ID_SET_ALL_TRACE_STATUS = 0xF0B,
+    DLT_USER_SERVICE_ID_LAST_ENTRY
+};
+
+/* Need to be adapted if another service is added */
+extern const char *const dlt_service_names[];
+extern const char *const dlt_user_service_names[];
+
+extern const char *dlt_get_service_name(unsigned int id);
 
 /*
  * Definitions of DLT service response status

--- a/include/dlt/dlt_protocol.h
+++ b/include/dlt/dlt_protocol.h
@@ -221,6 +221,15 @@
 #define DLT_CONNECTION_STATUS_DISCONNECTED 0x01 /**< Client is disconnected */
 #define DLT_CONNECTION_STATUS_CONNECTED    0x02 /**< Client is connected */
 
+/*
+ * Definitions of DLT GET_LOG_INFO status
+ */
+#define GET_LOG_INFO_STATUS_MIN 3
+#define GET_LOG_INFO_STATUS_MAX 7
+#define GET_LOG_INFO_STATUS_NO_MATCHING_CTX 8
+#define GET_LOG_INFO_STATUS_RESP_DATA_OVERFLOW 9
+
+
 /**
   \}
 */

--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -160,10 +160,10 @@ void set_timeout(long t)
 int dlt_parse_config_param(char *config_id, char **config_data)
 {
     FILE * pFile = NULL;
-    int value_length = DLT_RECEIVE_TEXTBUFSIZE;
-    char line[DLT_RECEIVE_TEXTBUFSIZE-1] = {0};
-    char token[DLT_RECEIVE_TEXTBUFSIZE] = {0};
-    char value[DLT_RECEIVE_TEXTBUFSIZE] = {0};
+    int value_length = DLT_LINE_LEN;
+    char line[DLT_LINE_LEN-1] = {0};
+    char token[DLT_LINE_LEN] = {0};
+    char value[DLT_LINE_LEN] = {0};
     char *pch = NULL;
     const char *filename = NULL;
 
@@ -524,7 +524,7 @@ static void *dlt_control_listen_to_daemon(void *data)
  */
 static int dlt_control_callback(DltMessage *message, void *data)
 {
-    char text[DLT_RECEIVE_TEXTBUFSIZE] = { 0 };
+    char text[DLT_RECEIVE_BUFSIZE] = { 0 };
     (void) data;
 
     if (message == NULL)
@@ -543,11 +543,11 @@ static int dlt_control_callback(DltMessage *message, void *data)
         dlt_set_storageheader(message->storageheader, "LCTL");
     }
 
-    dlt_message_header(message, text, DLT_RECEIVE_TEXTBUFSIZE, get_verbosity());
+    dlt_message_header(message, text, DLT_RECEIVE_BUFSIZE, get_verbosity());
 
     /* Extracting payload */
     dlt_message_payload(message, text,
-                        DLT_RECEIVE_TEXTBUFSIZE,
+                        DLT_RECEIVE_BUFSIZE,
                         DLT_OUTPUT_ASCII,
                         get_verbosity());
 

--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -69,7 +69,6 @@
 #define DLT_CTRL_APID    "DLTC"
 #define DLT_CTRL_CTID    "DLTC"
 #define DLT_DAEMON_DEFAULT_CTRL_SOCK_PATH "/tmp/dlt-ctrl.sock"
-#define DLT_RECEIVE_TEXTBUFSIZE 1024
 
 /** @brief Analyze the daemon answer
  *

--- a/src/console/dlt-control.c
+++ b/src/console/dlt-control.c
@@ -703,7 +703,7 @@ int main(int argc, char* argv[])
 
 int dlt_receive_message_callback(DltMessage *message, void *data)
 {
-    static char resp_text[DLT_RECEIVE_TEXTBUFSIZE];
+    static char resp_text[DLT_RECEIVE_BUFSIZE];
     int ret = DLT_RETURN_ERROR;
 
     /* parameter check */
@@ -725,7 +725,7 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
     }
 
     /* get response data */
-    ret = dlt_message_header(message, resp_text, DLT_RECEIVE_TEXTBUFSIZE, 0);
+    ret = dlt_message_header(message, resp_text, DLT_RECEIVE_BUFSIZE, 0);
     if (ret < 0)
     {
         fprintf(stderr, "GET_LOG_INFO message_header result failed..\n");
@@ -733,7 +733,7 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
         return -1;
     }
 
-    ret = dlt_message_payload(message, resp_text, DLT_RECEIVE_TEXTBUFSIZE, DLT_OUTPUT_ASCII, 0);
+    ret = dlt_message_payload(message, resp_text, DLT_RECEIVE_BUFSIZE, DLT_OUTPUT_ASCII, 0);
     if (ret < 0)
     {
         fprintf(stderr, "GET_LOG_INFO message_payload result failed..\n");

--- a/src/console/dlt-control.c
+++ b/src/console/dlt-control.c
@@ -185,6 +185,7 @@ void dlt_process_get_log_info(void)
     if (0 != dlt_client_get_log_info(&g_dltclient))
     {
         fprintf(stderr, "ERROR: Could not get log info\n");
+        dlt_client_cleanup_get_log_info(g_resp);
         return;
     }
 
@@ -197,7 +198,7 @@ void dlt_process_get_log_info(void)
     {
         app = g_resp->log_info_type.app_ids[i];
 
-        dlt_set_id(apid, app.app_id);
+        dlt_print_id(apid, app.app_id);
 
         if (app.app_description != 0)
         {
@@ -212,19 +213,28 @@ void dlt_process_get_log_info(void)
         {
             con = app.context_id_info[j];
 
-            dlt_set_id(ctid, con.context_id);
+            dlt_print_id(ctid, con.context_id);
 
-            printf("%4s %2d %2d %s\n",
+            if (con.context_description != 0)
+            {
+
+            printf("CTID:%4s %2d %2d %s\n",
                    ctid,
                    con.log_level,
                    con.trace_status,
                    con.context_description);
+            }
+            else
+            {
+                printf("CTID:%4s %2d %2d\n",
+                       ctid,
+                       con.log_level,
+                       con.trace_status);
+            }
          }
      }
 
-    dlt_client_free_get_log_info(g_resp);
-    free(g_resp);
-    g_resp = NULL;
+    dlt_client_cleanup_get_log_info(g_resp);
 }
 
 /**
@@ -695,7 +705,6 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
 {
     static char resp_text[DLT_RECEIVE_TEXTBUFSIZE];
     int ret = DLT_RETURN_ERROR;
-    char cb_result;
 
     /* parameter check */
     if (message == NULL)
@@ -740,7 +749,7 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
         return -1;
     }
 
-    ret = dlt_set_loginfo_parse_service_id(resp_text, &g_resp->service_id, &g_resp->status, &cb_result);
+    ret = dlt_set_loginfo_parse_service_id(resp_text, &g_resp->service_id, &g_resp->status);
     if ((ret == 0) && (g_resp->service_id == DLT_SERVICE_ID_GET_LOG_INFO))
     {
         ret = dlt_client_parse_get_log_info_resp_text(g_resp, resp_text);

--- a/src/console/dlt-receive.c
+++ b/src/console/dlt-receive.c
@@ -556,7 +556,7 @@ int main(int argc, char* argv[])
 int dlt_receive_message_callback(DltMessage *message, void *data)
 {
 	DltReceiveData *dltdata;
-    static char text[DLT_RECEIVE_TEXTBUFSIZE];
+    static char text[DLT_RECEIVE_BUFSIZE];
 
 	struct iovec iov[2];
     int bytes_written;
@@ -584,27 +584,27 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
         /* if no filter set or filter is matching display message */
         if (dltdata->xflag)
         {
-            dlt_message_print_hex(message,text,DLT_RECEIVE_TEXTBUFSIZE,dltdata->vflag);
+            dlt_message_print_hex(message,text,DLT_RECEIVE_BUFSIZE,dltdata->vflag);
         }
         else if (dltdata->aflag)
         {
 
-            dlt_message_header(message,text,DLT_RECEIVE_TEXTBUFSIZE,dltdata->vflag);
+            dlt_message_header(message,text,DLT_RECEIVE_BUFSIZE,dltdata->vflag);
 
             printf("%s ",text);
 
-            dlt_message_payload(message,text,DLT_RECEIVE_TEXTBUFSIZE,DLT_OUTPUT_ASCII,dltdata->vflag);
+            dlt_message_payload(message,text,DLT_RECEIVE_BUFSIZE,DLT_OUTPUT_ASCII,dltdata->vflag);
 
             printf("[%s]\n",text);
         }
         else if (dltdata->mflag)
         {
-            dlt_message_print_mixed_plain(message,text,DLT_RECEIVE_TEXTBUFSIZE,dltdata->vflag);
+            dlt_message_print_mixed_plain(message,text,DLT_RECEIVE_BUFSIZE,dltdata->vflag);
         }
         else if (dltdata->sflag)
         {
 
-            dlt_message_header(message,text,DLT_RECEIVE_TEXTBUFSIZE,dltdata->vflag);
+            dlt_message_header(message,text,DLT_RECEIVE_BUFSIZE,dltdata->vflag);
 
             printf("%s \n",text);
         }

--- a/src/console/dlt-receive.c
+++ b/src/console/dlt-receive.c
@@ -82,8 +82,6 @@
 
 #include "dlt_client.h"
 
-#define DLT_RECEIVE_TEXTBUFSIZE 10024  /* Size of buffer for text output */
-
 #define DLT_RECEIVE_ECU_ID "RECV"
 
 /* Function prototypes */

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -32,13 +32,13 @@ install(TARGETS dlt-daemon
 	COMPONENT base)
 
 if (WITH_DLT_UNIT_TESTS)
-    add_library(dlt_daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
+    add_library(dlt_daemon ${dlt_daemon_SRCS})
     target_link_libraries(dlt_daemon rt ${CMAKE_THREAD_LIBS_INIT})
     install(TARGETS dlt_daemon
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
-    COMPONENT base)
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
+            COMPONENT base)
 endif(WITH_DLT_UNIT_TESTS)
 
 INSTALL(FILES dlt.conf

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
     message( STATUS "Added ${systemd_SRCS} to dlt-daemon")
 endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
 
-set(dlt_daemon_SRCS dlt-daemon.c dlt_daemon_common.c dlt_daemon_connection.c dlt_daemon_event_handler.c ${CMAKE_SOURCE_DIR}/src/gateway/dlt_gateway.c dlt_daemon_socket.c dlt_daemon_unix_socket.c dlt_daemon_serial.c dlt_daemon_client.c dlt_daemon_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_offline_trace.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/lib/dlt_client.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_config_file_parser.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c)
+set(dlt_daemon_SRCS dlt-daemon.c dlt_daemon_common.c dlt_daemon_connection.c dlt_daemon_event_handler.c ${CMAKE_SOURCE_DIR}/src/gateway/dlt_gateway.c dlt_daemon_socket.c dlt_daemon_unix_socket.c dlt_daemon_serial.c dlt_daemon_client.c dlt_daemon_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_offline_trace.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/lib/dlt_client.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_config_file_parser.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
 add_executable(dlt-daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
 target_link_libraries(dlt-daemon rt ${CMAKE_THREAD_LIBS_INIT})
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -68,17 +68,6 @@
 #include "dlt_daemon_offline_logstorage.h"
 #include "dlt_gateway.h"
 
-/* checks if received size is big enough for expected data */
-#define DLT_CHECK_RCV_DATA_SIZE(received, required) \
-    ({ \
-        int _ret = DLT_RETURN_OK; \
-        if (((int)received - (int)required) < 0) { \
-            dlt_vlog(LOG_WARNING, "%s: Received data not complete\n", __func__); \
-            _ret = DLT_RETURN_ERROR; \
-        } \
-        _ret; \
-    })
-
 /** Global text output buffer, mainly used for creation of error/warning strings */
 static char str[DLT_DAEMON_TEXTBUFSIZE];
 

--- a/src/daemon/dlt_daemon_offline_logstorage.c
+++ b/src/daemon/dlt_daemon_offline_logstorage.c
@@ -388,7 +388,6 @@ STATIC DltReturnValue dlt_daemon_logstorage_update_passive_node_context(
     }
 
     return DLT_RETURN_OK;
-    return DLT_RETURN_OK;
 }
 
 /**

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -22,7 +22,7 @@
  * Christoph Lipka <clipka@jp.adit-jv.com>
  * Saya Sugiura <ssugiura@jp.adit-jv.com>
  *
- * \copyright Copyright © 2015-2017 Advanced Driver Information Technology. \n
+ * \copyright Copyright © 2015-2018 Advanced Driver Information Technology. \n
  * License MPL-2.0: Mozilla Public License version 2.0 http://mozilla.org/MPL/2.0/.
  *
  * \file dlt_gateway.c
@@ -72,7 +72,7 @@ typedef enum {
  * @param value string to be tested
  * @return 0 on success, -1 otherwise
  */
-STATIC int dlt_gateway_check_ip(DltGatewayConnection *con, char *value)
+STATIC DltReturnValue dlt_gateway_check_ip(DltGatewayConnection *con, char *value)
 {
     struct sockaddr_in sa;
     int ret = DLT_RETURN_ERROR;
@@ -316,7 +316,7 @@ STATIC int dlt_gateway_check_control_messages(DltGatewayConnection *con,
 
     while (token != NULL)
     {
-        if (dlt_gateway_allocate_control_messages(con) == -1)
+        if (dlt_gateway_allocate_control_messages(con) != DLT_RETURN_OK)
         {
             dlt_log(LOG_ERR,
                     "Passive Control Message could not be allocated\n");
@@ -443,7 +443,7 @@ STATIC int dlt_gateway_check_periodic_control_messages(DltGatewayConnection *con
                     con->p_control_msgs = con->p_control_msgs->next;
                 }
 
-                if (dlt_gateway_allocate_control_messages(con) == -1)
+                if (dlt_gateway_allocate_control_messages(con) != DLT_RETURN_OK)
                 {
                     dlt_log(LOG_ERR,
                             "Passive Control Message could not be allocated\n");
@@ -1056,7 +1056,7 @@ STATIC int dlt_gateway_parse_get_log_info(DltDaemon *daemon,
                                           int req,
                                           int verbose)
 {
-    char resp_text[DLT_RECEIVE_TEXTBUFSIZE] = {'\0'};
+    char resp_text[DLT_RECEIVE_BUFSIZE] = {'\0'};
     DltServiceGetLogInfoResponse *resp = NULL;
     AppIDsType app;
     ContextIDsInfoType con;
@@ -1097,7 +1097,7 @@ STATIC int dlt_gateway_parse_get_log_info(DltDaemon *daemon,
     /* check response */
     if (dlt_message_payload(msg,
                             resp_text,
-                            DLT_RECEIVE_TEXTBUFSIZE,
+                            DLT_RECEIVE_BUFSIZE,
                             DLT_OUTPUT_ASCII, 0) != DLT_RETURN_OK)
     {
         dlt_log(LOG_ERR, "GET_LOG_INFO payload failed\n");
@@ -1272,16 +1272,15 @@ STATIC int dlt_gateway_control_service_logstorage(DltDaemon *daemon,
     return DLT_RETURN_OK;
 }
 
-int dlt_gateway_process_passive_node_messages(DltDaemon *daemon,
-                                              DltDaemonLocal *daemon_local,
-                                              DltReceiver *receiver,
-                                              int verbose)
+DltReturnValue dlt_gateway_process_passive_node_messages(DltDaemon *daemon,
+                                             DltDaemonLocal *daemon_local,
+                                             DltReceiver *receiver,
+                                             int verbose)
 {
     int i = 0;
     DltGateway *gateway = NULL;
     DltGatewayConnection *con = NULL;
     DltMessage msg;
-    char local_str[DLT_DAEMON_TEXTBUFSIZE];
 
     if ((daemon == NULL) || (daemon_local == NULL) || (receiver == NULL))
     {
@@ -1427,7 +1426,7 @@ int dlt_gateway_process_passive_node_messages(DltDaemon *daemon,
                                       msg.headerextra.ecu) == DLT_RETURN_ERROR)
             {
                 dlt_vlog(LOG_ERR, "%s: Can't set storage header\n", __func__);
-                return DLT_DAEMON_ERROR_UNKNOWN;
+                return DLT_RETURN_ERROR;
             }
 
             if (dlt_daemon_client_send(DLT_DAEMON_SEND_TO_ALL,

--- a/src/gateway/dlt_gateway.conf
+++ b/src/gateway/dlt_gateway.conf
@@ -9,11 +9,14 @@ EcuID=ECU2
 ; Stop connecting to passive node, if not successful after 10 seconds
 Timeout=10
 ; Send following control messages after connection is established
-; SendControl=0x03,0x13
+; SendControl=0x03,0x04,0x13
 ; Send Serial Header with control messages. Value in dlt.conf is used as default if not specified.
 ; SendSerialHeader=0
+; Send following control messages periodically (<control:interval[in seconds]>)
+; SendPeriodicControl=0x03:5,0x13:10
 
 
 ; Supported Control messages:
 ; DLT_SERVICE_ID_GET_LOG_INFO                    0x03
+; DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL           0x04
 ; DLT_SERVICE_ID_GET_SOFTWARE_VERSION            0x13

--- a/src/gateway/dlt_gateway.h
+++ b/src/gateway/dlt_gateway.h
@@ -163,17 +163,18 @@ int dlt_gateway_process_on_demand_request(DltGateway *g,
                                           int verbose);
 
 /**
- * Send control message to passive node.
+ * Send control message to passive node
  *
  * @param con           DltGatewayConnection
- * @param g             DltGateway
- * @param daemon_local  DltDaemonLocal
+ * @param control_msg   DltPassiveControlMessage
+ * @param msg           DltMessage
  * @param verbose       verbose flag
+ * @return 0 on success, -1 otherwise
  */
-void dlt_gateway_send_control_message(DltGatewayConnection *con,
-                                      DltGateway *g,
-                                      DltDaemonLocal *daemon_local,
-                                      int verbose);
+int dlt_gateway_send_control_message(DltGatewayConnection *con,
+                                     DltPassiveControlMessage *control_msg,
+                                     void *data,
+                                     int verbose);
 
 /**
  * Gets the connection handle of passive node with specified ECU
@@ -189,33 +190,4 @@ DltGatewayConnection *dlt_gateway_get_connection(DltGateway *g,
 
 /* _ONLY_ for development purposes */
 void print_gateway_connection_details(const DltGateway *g);
-#ifdef DLT_UNIT_TESTS
-typedef enum {
-    GW_CONF_IP_ADDRESS = 0,
-    GW_CONF_PORT,
-    GW_CONF_ECUID,
-    GW_CONF_CONNECT,
-    GW_CONF_TIMEOUT,
-    GW_CONF_SEND_CONTROL,
-    GW_CONF_SEND_SERIAL_HEADER,
-    GW_CONF_COUNT
-} DltGatewayConfType;
-int dlt_gateway_check_ip(DltGatewayConnection *con, char *value);
-int dlt_gateway_check_port(DltGatewayConnection *con, char *value);
-int dlt_gateway_check_ecu(DltGatewayConnection *con, char *value);
-int dlt_gateway_check_connect_trigger(DltGatewayConnection *con,
-                                             char *value);
-int dlt_gateway_check_timeout(DltGatewayConnection *con, char *value);
-int dlt_gateway_check_send_serial(DltGatewayConnection *con, char *value);
-int dlt_gateway_check_control_messages(DltGatewayConnection *con,
-                                              char *value);
-int dlt_gateway_check_param(DltGateway *gateway,
-                                   DltGatewayConnection *con,
-                                   DltGatewayConfType ctype,
-                                   char *value);
-int dlt_gateway_configure(DltGateway *gateway, char *config_file, int verbose);
-int dlt_gateway_store_connection(DltGateway *gateway,
-                                 DltGatewayConnection *tmp,
-                                 int verbose);
-#endif
 #endif

--- a/src/gateway/dlt_gateway_types.h
+++ b/src/gateway/dlt_gateway_types.h
@@ -58,6 +58,7 @@
 #ifndef DLT_GATEWAY_TYPES_H_
 #define DLT_GATEWAY_TYPES_H_
 
+#include "dlt_protocol.h"
 #include "dlt_client.h"
 
 #define DLT_GATEWAY_CONFIG_PATH CONFIGURATION_FILES_DIR "/dlt_gateway.conf"
@@ -85,6 +86,32 @@ typedef enum
     DLT_GATEWAY_DISABLED       /* disable this connection due to problems */
 } connection_trigger;
 
+typedef enum
+{
+    CONTROL_MESSAGE_UNDEFINED = -1,
+    CONTROL_MESSAGE_ON_STARTUP,     /* send on startup */
+    CONTROL_MESSAGE_PERIODIC,       /* send periodically */
+    CONTROL_MESSAGE_BOTH,           /* send on startup and periodically */
+    CONTROL_MESSAGE_ON_DEMAND       /* send on demand only */
+} control_msg_trigger;
+
+typedef enum
+{
+    CONTROL_MESSAGE_REQUEST_UNDEFINED = -1,
+    CONTROL_MESSAGE_NOT_REQUESTED,  /* control msg not requested (default) */
+    CONTROL_MESSAGE_REQUESTED       /* control msg requested */
+} control_msg_request;
+
+/* Passive control message */
+typedef struct DltPassiveControlMessage {
+    uint32_t id;                /* msg ID */
+    uint32_t user_id;
+    control_msg_trigger type;   /* on startup or periodic or both */
+    control_msg_request req;    /* whether it is requested from gateway or not */
+    int interval;               /* interval for periodic sending. if on startup, -1 */
+    struct DltPassiveControlMessage *next; /* for multiple passive control message */
+} DltPassiveControlMessage;
+
 /* DLT Gateway connection structure */
 typedef struct {
     int handle;                 /* connection handle */
@@ -99,9 +126,13 @@ typedef struct {
     int timeout;                /* connection timeout */
     int timeout_cnt;            /* connection timeout counter */
     int reconnect_cnt;          /* reconnection counter */
-    int control_msgs[DLT_GATEWAY_MAX_STARTUP_CTRL_MSG]; /* msg IDs send on startup */
+    int sendtime;               /* periodic sending max time */
+    int sendtime_cnt;           /* periodic sending counter */
+    DltPassiveControlMessage *p_control_msgs; /* passive control msgs */
+    DltPassiveControlMessage *head; /* to go back to the head pointer of p_control_msgs */
     int send_serial;            /* Send serial header with control messages */
     DltClient client;           /* DltClient structure */
+    int default_log_level;      /* Default Log Level on passive node */
 } DltGatewayConnection;
 
 /* DltGateway structure */

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -15,7 +15,7 @@
 # @licence end@
 #######
 
-set(dlt_LIB_SRCS dlt_user dlt_client dlt_filetransfer dlt_env_ll ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c)
+set(dlt_LIB_SRCS dlt_user dlt_client dlt_filetransfer dlt_env_ll ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
 
 add_library(dlt ${dlt_LIB_SRCS})
 target_link_libraries(dlt rt ${CMAKE_THREAD_LIBS_INIT})

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -289,7 +289,7 @@ DltReturnValue dlt_client_connect(DltClient *client, int verbose)
         return DLT_RETURN_ERROR;
     }
 
-    if (dlt_receiver_init(&(client->receiver),client->sock,DLT_CLIENT_RCVBUFSIZE) != DLT_RETURN_OK)
+    if (dlt_receiver_init(&(client->receiver), client->sock, DLT_RECEIVE_BUFSIZE) != DLT_RETURN_OK)
     {
         fprintf(stderr, "ERROR initializing receiver\n");
         return DLT_RETURN_ERROR;
@@ -1011,7 +1011,7 @@ STATIC void dlt_client_free_calloc_failed_get_log_info(DltServiceGetLogInfoRespo
     return;
 }
 
-int dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
+DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
                                              char *resp_text)
 {
     AppIDsType *app = NULL;
@@ -1023,7 +1023,7 @@ int dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
 
     if ((resp == NULL) || (resp_text == NULL))
     {
-        return DLT_RETURN_ERROR;
+        return DLT_RETURN_WRONG_PARAMETER;
     }
 
     /* ------------------------------------------------------

--- a/src/lib/dlt_client_cfg.h
+++ b/src/lib/dlt_client_cfg.h
@@ -82,9 +82,6 @@
 /* Size of buffer */
 #define DLT_CLIENT_TEXTBUFSIZE          512
 
-/* Size of receive buffer */
-#define DLT_CLIENT_RCVBUFSIZE         10024
-
 /* Initial baudrate */
 #if !defined (__WIN32__) && !defined(_MSC_VER)
 #define DLT_CLIENT_INITIAL_BAUDRATE B115200

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -3948,7 +3948,7 @@ int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count)
 
     if ((rp == NULL) || (rp_count == NULL))
     {
-        return DLT_RETURN_ERROR;
+        return -1;
     }
     /* ------------------------------------------------------
        from: [89 13 ] -> to: ['+0x'1389\0] -> to num
@@ -3970,7 +3970,7 @@ int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count)
 
     if ((rp == NULL) || (rp_count == NULL))
     {
-        return DLT_RETURN_ERROR;
+        return -1;
     }
     /* ------------------------------------------------------
        from: [89 ] -> to: ['0x'89\0] -> to num

--- a/src/shared/dlt_protocol.c
+++ b/src/shared/dlt_protocol.c
@@ -1,0 +1,90 @@
+/*
+ * @licence app begin@
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2016 Advanced Driver Information Technology.
+ * This code is developed by Advanced Driver Information Technology.
+ * Copyright of Advanced Driver Information Technology, Bosch and DENSO.
+ *
+ * This file is part of GENIVI Project DLT - Diagnostic Log and Trace.
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License (MPL), v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * For further information see http://www.genivi.org/.
+ * @licence end@
+ */
+
+/*!
+ * \author
+ * Christoph Lipka <clipka@jp.adit-jv.com>
+ *
+ * \copyright Copyright © 2016 Advanced Driver Information Technology. \n
+ * License MPL-2.0: Mozilla Public License version 2.0 http://mozilla.org/MPL/2.0/.
+ *
+ * \file dlt_protocol.c
+ */
+
+#include "dlt_protocol.h"
+
+const char *const dlt_service_names[] =
+{
+    "DLT_SERVICE_ID",
+    "DLT_SERVICE_ID_SET_LOG_LEVEL",
+    "DLT_SERVICE_ID_SET_TRACE_STATUS",
+    "DLT_SERVICE_ID_GET_LOG_INFO",
+    "DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL",
+    "DLT_SERVICE_ID_STORE_CONFIG",
+    "DLT_SERVICE_ID_RESET_TO_FACTORY_DEFAULT",
+    "DLT_SERVICE_ID_SET_COM_INTERFACE_STATUS",
+    "DLT_SERVICE_ID_SET_COM_INTERFACE_MAX_BANDWIDTH",
+    "DLT_SERVICE_ID_SET_VERBOSE_MODE",
+    "DLT_SERVICE_ID_SET_MESSAGE_FILTERING",
+    "DLT_SERVICE_ID_SET_TIMING_PACKETS",
+    "DLT_SERVICE_ID_GET_LOCAL_TIME",
+    "DLT_SERVICE_ID_USE_ECU_ID",
+    "DLT_SERVICE_ID_USE_SESSION_ID",
+    "DLT_SERVICE_ID_USE_TIMESTAMP",
+    "DLT_SERVICE_ID_USE_EXTENDED_HEADER",
+    "DLT_SERVICE_ID_SET_DEFAULT_LOG_LEVEL",
+    "DLT_SERVICE_ID_SET_DEFAULT_TRACE_STATUS",
+    "DLT_SERVICE_ID_GET_SOFTWARE_VERSION",
+    "DLT_SERVICE_ID_MESSAGE_BUFFER_OVERFLOW"
+};
+const char *const dlt_user_service_names[] =
+{
+    "DLT_USER_SERVICE_ID",
+    "DLT_SERVICE_ID_UNREGISTER_CONTEXT",
+    "DLT_SERVICE_ID_CONNECTION_INFO",
+    "DLT_SERVICE_ID_TIMEZONE",
+    "DLT_SERVICE_ID_MARKER",
+    "DLT_SERVICE_ID_OFFLINE_LOGSTORAGE",
+    "DLT_SERVICE_ID_SET_FILTER_LEVEL",
+    "DLT_SERVICE_ID_GET_FILTER_STATUS",
+    "DLT_SERVICE_ID_PASSIVE_NODE_CONNECT",
+    "DLT_SERVICE_ID_PASSIVE_NODE_CONNECTION_STATUS",
+    "DLT_SERVICE_ID_SET_ALL_LOG_LEVEL"
+};
+
+const char *dlt_get_service_name(unsigned int id)
+{
+    if (id == DLT_SERVICE_ID_CALLSW_CINJECTION)
+    {
+        return "DLT_SERVICE_ID_CALLSW_CINJECTION";
+    }
+    else if ((id == DLT_SERVICE_ID) || (id >= DLT_USER_SERVICE_ID_LAST_ENTRY) ||
+             (id >= DLT_SERVICE_ID_LAST_ENTRY && id <= DLT_USER_SERVICE_ID))
+    {
+        return "UNDEFINED";
+    }
+    else if ((id > DLT_SERVICE_ID) && (id < DLT_SERVICE_ID_LAST_ENTRY))
+    {
+        return dlt_service_names[id];
+    }
+    else /* user services */
+    {
+        return dlt_user_service_names[id&0xFF];
+    }
+}

--- a/tests/dlt_test_receiver.c
+++ b/tests/dlt_test_receiver.c
@@ -326,7 +326,7 @@ int main(int argc, char* argv[])
 int dlt_receive_filetransfer_callback(DltMessage *message, void *data)
 {
     DltReceiveData *dltdata;
-    static char text[DLT_RECEIVE_TEXTBUFSIZE];
+    static char text[DLT_RECEIVE_BUFSIZE];
     char filename[255];
     struct iovec iov[2];
     int bytes_written;
@@ -340,7 +340,7 @@ int dlt_receive_filetransfer_callback(DltMessage *message, void *data)
 
     if(dltdata->filetransfervalue)
     {
-        dlt_message_print_ascii(message, text, DLT_RECEIVE_TEXTBUFSIZE, dltdata->vflag);
+        dlt_message_print_ascii(message, text, DLT_RECEIVE_BUFSIZE, dltdata->vflag);
 
         // 1st find starting point of tranfering data packages
         if( strncmp(text, "FLST", 4) == 0)
@@ -373,11 +373,11 @@ int dlt_receive_filetransfer_callback(DltMessage *message, void *data)
         {
             // truncate beginning of data stream ( FLDA, File identifier and package number)
             char *position = strchr(text, 32); // search for space
-            strncpy(text, position+1, DLT_RECEIVE_TEXTBUFSIZE);
+            strncpy(text, position+1, DLT_RECEIVE_BUFSIZE);
             position = strchr(text, 32);
-            strncpy(text, position+1, DLT_RECEIVE_TEXTBUFSIZE);
+            strncpy(text, position+1, DLT_RECEIVE_BUFSIZE);
             position = strchr(text, 32);
-            strncpy(text, position+1, DLT_RECEIVE_TEXTBUFSIZE);
+            strncpy(text, position+1, DLT_RECEIVE_BUFSIZE);
 
             // truncate ending of data stream ( FLDA )
             int len = strlen(text);
@@ -398,7 +398,7 @@ int dlt_receive_filetransfer_callback(DltMessage *message, void *data)
 
     if(dltdata->systemjournalvalue)
     {
-        dlt_message_print_ascii(message, text, DLT_RECEIVE_TEXTBUFSIZE, dltdata->vflag);
+        dlt_message_print_ascii(message, text, DLT_RECEIVE_BUFSIZE, dltdata->vflag);
         // 1st find the relevant packages
         char * tmp = message->extendedheader->ctid;
         tmp[4] = '\0';
@@ -415,7 +415,7 @@ int dlt_receive_filetransfer_callback(DltMessage *message, void *data)
 
     if(dltdata->systemloggervalue)
     {
-        dlt_message_print_ascii(message, text, DLT_RECEIVE_TEXTBUFSIZE, dltdata->vflag);
+        dlt_message_print_ascii(message, text, DLT_RECEIVE_BUFSIZE, dltdata->vflag);
         // 1st find the relevant packages
         char * tmp = message->extendedheader->ctid;
         tmp[4] = '\0';

--- a/tests/g_test_dlt_daemon_gateway.sh
+++ b/tests/g_test_dlt_daemon_gateway.sh
@@ -54,9 +54,9 @@ cleanup()
             return 1
         fi
     fi
-    return 0
-
     rm $tmpPath/dlt.conf
+    rm $tmpPath/idlt_gateway.conf
+    return 0
 }
 #
 # Function:     -setupTest()
@@ -106,6 +106,8 @@ setupTest()
     echo "EcuID=ECU1" >>$tmpPath/dlt_gateway.conf
     echo "Connect=OnStartup" >>$tmpPath/dlt_gateway.conf
     echo "Timeout=10" >>$tmpPath/dlt_gateway.conf
+    echo "SendControl=0x03,0x13" >>$tmpPath/dlt_gateway.conf
+    echo "SendSerialHeader=0" >>$tmpPath/dlt_gateway.conf
     echo "NOFiles=1" >>$tmpPath/dlt_gateway.conf
     return 0
 }

--- a/tests/gtest_common.h
+++ b/tests/gtest_common.h
@@ -1,0 +1,251 @@
+/**
+ * @licence app begin@
+ * Copyright (C) 2016  Advanced Driver Information Technology.
+ * This code is developed by Advanced Driver Information Technology.
+ * Copyright of Advanced Driver Information Technology, Bosch and DENSO.
+ *
+ * DLT gtest common header file.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *
+ * \author Onkar Palkar <onkar.palkar@wipro.com>
+ *
+ * \file: gtest_common.h
+ * For further information see http://www.genivi.org/.
+ * @licence end@
+ */
+
+/*******************************************************************************
+ *                                                                            **
+ *  SRC-MODULE: gtest_common.h                                                **
+ *                                                                            **
+ *  TARGET    : linux                                                         **
+ *                                                                            **
+ *  PROJECT   : DLT                                                           **
+ *                                                                            **
+ *  AUTHOR    : onkar.palkar@wipro.com                                        **
+ *  PURPOSE   :                                                               **
+ *                                                                            **
+ *  REMARKS   :                                                               **
+ *                                                                            **
+ *  PLATFORM DEPENDANT [yes/no]: yes                                          **
+ *                                                                            **
+ *  TO BE CHANGED BY USER [yes/no]: no                                        **
+ *                                                                            **
+ ******************************************************************************/
+
+/*******************************************************************************
+*                      Author Identity                                       **
+*******************************************************************************
+*                                                                            **
+* Initials     Name                       Company                            **
+* --------     -------------------------  ---------------------------------- **
+*  op          Onkar Palkar               Wipro                              **
+*******************************************************************************/
+#ifndef GTEST_COMMON_H
+#define GTEST_COMMON_H
+int dlt_logstorage_split_key(char *key, char *appid, char *ctxid);
+int dlt_logstorage_update_all_contexts(DltDaemon *daemon,
+                                       char *id,
+                                       int curr_log_level,
+                                       int cmp_flag,
+                                       int verbose);
+int dlt_logstorage_update_context(DltDaemon *daemon,
+                                  char *apid,
+                                  char *ctxid,
+                                  char *ecuid,
+                                  int curr_log_level,
+                                  int verbose);
+int dlt_logstorage_update_context_loglevel(DltDaemon *daemon,
+                                           char *key,
+                                           int curr_log_level,
+                                           int verbose);
+void dlt_daemon_logstorage_reset_application_loglevel(DltDaemon *daemon,
+                                                      int dev_num,
+                                                      int max_device,
+                                                      int verbose);
+typedef struct {
+    char *key; /* The configuration key */
+    int (*func)(DltLogStorage *handle, char *value); /* conf handler */
+    int is_opt; /* If configuration is optional or not */
+} DltLogstorageGeneralConf;
+
+typedef enum {
+    DLT_LOGSTORAGE_GENERAL_CONF_BLOCKMODE = 0,
+    DLT_LOGSTORAGE_GENERAL_CONF_COUNT
+} DltLogstorageGeneralConfType;
+
+typedef struct {
+    char *key; /* Configuration key */
+    int (*func)(DltLogStorageFilterConfig *config, char *value); /* conf handler */
+    int is_opt; /* If configuration is optional or not */
+} DltLogstorageFilterConf;
+
+typedef enum {
+    DLT_LOGSTORAGE_FILTER_CONF_LOGAPPNAME = 0,
+    DLT_LOGSTORAGE_FILTER_CONF_CONTEXTNAME,
+    DLT_LOGSTORAGE_FILTER_CONF_LOGLEVEL,
+    DLT_LOGSTORAGE_FILTER_CONF_FILE,
+    DLT_LOGSTORAGE_FILTER_CONF_FILESIZE,
+    DLT_LOGSTORAGE_FILTER_CONF_NOFILES,
+    DLT_LOGSTORAGE_FILTER_CONF_SYNCBEHAVIOR,
+    DLT_LOGSTORAGE_FILTER_CONF_ECUID,
+    DLT_LOGSTORAGE_FILTER_CONF_COUNT
+} DltLogstorageFilterConfType;
+
+    int dlt_logstorage_hash_create(int num_entries,
+                                   struct hsearch_data *htab);
+    int dlt_logstorage_hash_destroy(struct hsearch_data *htab);
+    int dlt_logstorage_hash_add(char *key, void *value,
+                                   struct hsearch_data *htab);
+    void *dlt_logstorage_hash_find(char *key, struct hsearch_data *htab);
+    int dlt_logstorage_count_ids(const char *str);
+    int dlt_logstorage_read_number(unsigned int *number, char *value);
+    int dlt_logstorage_read_list_of_names(char **names, char *value);
+    int dlt_logstorage_check_apids(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_ctids(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_loglevel(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_filename(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_filesize(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_nofiles(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_sync_strategy(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_ecuid(DltLogStorageFilterConfig *config, char *value);
+    int dlt_logstorage_check_param(DltLogStorageFilterConfig *config,
+                                      DltLogstorageFilterConfType ctype,
+                                      char *value);
+    int dlt_logstorage_check_blockmode(DltLogStorage *handle,
+                                          char *value);
+    int dlt_logstorage_check_general_param(DltLogStorage *handle,
+                                              DltLogstorageGeneralConfType ctype,
+                                              char *value);
+    int dlt_daemon_setup_general_properties(DltLogStorage *handle,
+                                               DltConfigFile *config_file,
+                                               char *sec_name);
+    int dlt_logstorage_store_filters(DltLogStorage *handle,
+                                        char *config_file_name);
+    void dlt_logstorage_free(DltLogStorage *handle, int reason);
+    int dlt_logstorage_create_keys(char *appids,
+                                      char *ctxids,
+                                      char **keys,
+                                      int *num_keys);
+    int dlt_logstorage_prepare_table(DltLogStorage *handle,
+                                        DltLogStorageFilterConfig *data);
+    int dlt_logstorage_validate_filter_name(char *name);
+    void dlt_logstorage_filter_set_strategy(DltLogStorageFilterConfig *config,
+                                               int strategy);
+    int dlt_logstorage_load_config(DltLogStorage *handle);
+    int dlt_logstorage_filter(DltLogStorage *handle,
+                              DltLogStorageFilterConfig **config,
+                              char *apid,
+                              char *ctid,
+                              char *ecuid,
+                              int log_level);
+void dlt_logstorage_log_file_name(char *log_file_name,
+                                  DltLogStorageUserConfig *file_config,
+                                  char *name,
+                                  int idx);
+void dlt_logstorage_sort_file_name(DltLogStorageFileList **head);
+void dlt_logstorage_rearrange_file_name(DltLogStorageFileList **head);
+unsigned int dlt_logstorage_get_idx_of_log_file(
+    DltLogStorageUserConfig *file_config,
+    char *file);
+int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
+                                    char *path,
+                                    DltLogStorageFilterConfig *config);
+int dlt_logstorage_open_log_file(DltLogStorageFilterConfig *config,
+                                 DltLogStorageUserConfig *file_config,
+                                 char *dev_path,
+                                 int msg_size);
+/* gtest_dlt_daemon_gateway */
+typedef enum {
+    GW_CONF_IP_ADDRESS = 0,
+    GW_CONF_PORT,
+    GW_CONF_ECUID,
+    GW_CONF_CONNECT,
+    GW_CONF_TIMEOUT,
+    GW_CONF_SEND_CONTROL,
+    GW_CONF_SEND_PERIODIC_CONTROL,
+    GW_CONF_SEND_SERIAL_HEADER,
+    GW_CONF_COUNT
+} DltGatewayConfType;
+int enable_all(DltServiceIdFlag *flags);
+int init_flags(DltServiceIdFlag *flags);
+int set_bit(DltServiceIdFlag *flags, int id);
+int bit(DltServiceIdFlag *flags, int id);
+int dlt_daemon_filter_name(DltMessageFilter *mf,
+                                   DltFilterConfiguration *config,
+                                   char *value);
+int dlt_daemon_filter_level(DltMessageFilter *mf,
+                                   DltFilterConfiguration *config,
+                                   char *value);
+int dlt_daemon_filter_control_mask(DltMessageFilter *mf,
+                                          DltFilterConfiguration *config,
+                                          char *value);
+int dlt_daemon_filter_client_mask(DltMessageFilter *mf,
+                                         DltFilterConfiguration *config,
+                                         char *value);
+int dlt_daemon_filter_injections(DltMessageFilter *mf,
+                                        DltFilterConfiguration *config,
+                                        char *value);
+int dlt_daemon_set_injection_service_ids(int **ids,
+                                                int *num,
+                                                char *value);
+DltInjectionConfig *dlt_daemon_filter_find_injection_by_name(
+    DltInjectionConfig *injections,
+    char *name);
+int dlt_daemon_injection_name(DltMessageFilter *mf,
+                                         DltInjectionConfig *config,
+                                         char *value);
+int dlt_daemon_injection_apid(DltMessageFilter *mf,
+                                         DltInjectionConfig *config,
+                                         char *value);
+int dlt_daemon_injection_ctid(DltMessageFilter *mf,
+                                         DltInjectionConfig *config,
+                                         char *value);
+int dlt_daemon_injection_ecu_id(DltMessageFilter *mf,
+                                           DltInjectionConfig *config,
+                                           char *value);
+int dlt_daemon_injection_service_id(DltMessageFilter *mf,
+                                               DltInjectionConfig *config,
+                                               char *value);
+int dlt_daemon_get_name(DltMessageFilter *mf, char *val);
+int dlt_daemon_get_default_level(DltMessageFilter *mf, char *val);
+int dlt_daemon_get_backend(DltMessageFilter *mf, char *val);
+int dlt_daemon_setup_filter_section(DltMessageFilter *mf,
+                                           DltConfigFile *config,
+                                           char *sec_name);
+int dlt_daemon_setup_filter_properties(DltMessageFilter *mf,
+                                              DltConfigFile *config,
+                                              char *sec_name);
+void dlt_daemon_filter_backend_level_changed(unsigned int level,
+                                             void *ptr1,
+                                             void *ptr2);
+int dlt_gateway_check_ip(DltGatewayConnection *con, char *value);
+int dlt_gateway_check_port(DltGatewayConnection *con, char *value);
+int dlt_gateway_check_ecu(DltGatewayConnection *con, char *value);
+int dlt_gateway_check_connect_trigger(DltGatewayConnection *con,
+                                             char *value);
+int dlt_gateway_check_timeout(DltGatewayConnection *con, char *value);
+int dlt_gateway_check_send_serial(DltGatewayConnection *con, char *value);
+int dlt_gateway_allocate_control_messages(DltGatewayConnection *con);
+int dlt_gateway_check_control_messages(DltGatewayConnection *con,
+                                              char *value);
+int dlt_gateway_check_periodic_control_messages(DltGatewayConnection *con,
+                                              char *value);
+int dlt_gateway_check_param(DltGateway *gateway,
+                                   DltGatewayConnection *con,
+                                   DltGatewayConfType ctype,
+                                   char *value);
+int dlt_gateway_configure(DltGateway *gateway, char *config_file, int verbose);
+int dlt_gateway_store_connection(DltGateway *gateway,
+                                 DltGatewayConnection *tmp,
+                                 int verbose);
+int dlt_gateway_parse_get_log_info(DltDaemon *daemon,
+                                   char *ecu,
+                                   DltMessage *msg,
+                                   int verbose);
+#endif

--- a/tests/gtest_dlt_daemon_event_handler.cpp
+++ b/tests/gtest_dlt_daemon_event_handler.cpp
@@ -216,6 +216,7 @@ TEST(t_dlt_event_handler_cleanup_connections, normal)
 }
 
 /* Begin Method: dlt_daemon_event_handler::dlt_connection_check_activate*/
+/*
 TEST(t_dlt_connection_check_activate, normal)
 {
     int ret;
@@ -240,7 +241,7 @@ TEST(t_dlt_connection_check_activate, nullpointer)
 {
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_connection_check_activate(NULL, NULL, DEACTIVATE));
 }
-
+*/
 /* Begin Method: dlt_daemon_event_handler::dlt_event_handler_register_connection*/
 TEST(t_dlt_event_handler_register_connection, normal)
 {

--- a/tests/gtest_dlt_daemon_gateway.cpp
+++ b/tests/gtest_dlt_daemon_gateway.cpp
@@ -61,35 +61,8 @@
 
 extern "C"
 {
-#include "dlt-daemon.h"
-#include "dlt_user.h"
-#include "dlt_user_shared.h"
-#include "dlt_user_shared_cfg.h"
-#include "dlt_user_cfg.h"
-#include "dlt-daemon_cfg.h"
-#include "dlt_version.h"
 #include "dlt_gateway.h"
-#include "dlt_daemon_common.h"
-#include "dlt_daemon_connection_types.h"
-#include "dlt_daemon_event_handler.h"
-#include "dlt_daemon_connection.h"
-#include "dlt_daemon_event_handler_types.h"
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <limits.h>
-#include <errno.h>
-#include "dlt_config_file_parser.h"
-#include "dlt_common.h"
-#include "dlt-daemon_cfg.h"
-#include "dlt_daemon_event_handler.h"
-#include "dlt_daemon_connection.h"
-#include "dlt_daemon_client.h"
+#include "gtest_common.h"
 }
 
 /* Begin Method: dlt_gateway::t_dlt_gateway_init*/
@@ -99,17 +72,20 @@ TEST(t_dlt_gateway_init, normal)
     DltGatewayConnection connections;
     daemon_local.pGateway.connections = &connections;
     daemon_local.pGateway.num_connections = 1;
-
+    daemon_local.flags.lflag = 0;
+    DltFilterConfiguration current;
+    daemon_local.pFilter.current = &current;
     DltConnection connections1;
     DltReceiver receiver;
     daemon_local.pEvent.connections = &connections1;
     daemon_local.pEvent.connections->receiver = &receiver;
     daemon_local.pEvent.connections->next = NULL;
-
     memset(daemon_local.flags.gatewayConfigFile,0,DLT_DAEMON_FLAG_MAX);
     strncpy(daemon_local.flags.gatewayConfigFile, "/tmp/dlt_gateway.conf", DLT_DAEMON_FLAG_MAX - 1);
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_init(&daemon_local, 1));
+
+    dlt_gateway_deinit(&daemon_local.pGateway, 0);
 }
 
 TEST(t_dlt_gateway_init, nullpointer)
@@ -123,6 +99,8 @@ TEST(t_dlt_gateway_send_control_message, Normal)
 {
     int ret = 0;
     DltDaemonLocal daemon_local;
+    DltFilterConfiguration current;
+    daemon_local.pFilter.current = &current;
     DltGatewayConnection connections;
     DltConnection connections1;
     DltReceiver receiver1;
@@ -132,11 +110,12 @@ TEST(t_dlt_gateway_send_control_message, Normal)
     daemon_local.pEvent.connections->receiver = &receiver1;
     memset(daemon_local.flags.gatewayConfigFile,0,DLT_DAEMON_FLAG_MAX);
     strncpy(daemon_local.flags.gatewayConfigFile, "/tmp/dlt_gateway.conf", DLT_DAEMON_FLAG_MAX - 1);
-
     ret = dlt_gateway_init(&daemon_local, 0);
+
     EXPECT_EQ(DLT_RETURN_OK, ret);
 
-    dlt_gateway_send_control_message(daemon_local.pGateway.connections, &daemon_local.pGateway, &daemon_local, 0);
+    dlt_gateway_send_control_message(daemon_local.pGateway.connections, daemon_local.pGateway.connections->p_control_msgs, NULL, 0);
+    dlt_gateway_deinit(&daemon_local.pGateway, 0);
 }
 
 TEST(t_dlt_gateway_send_control_message, nullpointer)
@@ -153,11 +132,9 @@ TEST(t_dlt_gateway_store_connection, normal)
     DltGateway gateway;
     DltGatewayConnection tmp;
     DltGatewayConnection tmp1;
-
     gateway.num_connections = 1;
     gateway.connections = &tmp1;
     gateway.connections->status = DLT_GATEWAY_UNINITIALIZED;
-
     tmp.ip_address = ip_address;
     tmp.ecuid = ecuid;
     tmp.sock_domain = 1;
@@ -168,12 +145,18 @@ TEST(t_dlt_gateway_store_connection, normal)
     tmp.timeout = 500;
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_store_connection(&gateway, &tmp, 0));
+    EXPECT_EQ(gateway.connections->sock_domain, tmp.sock_domain);
+    EXPECT_EQ(gateway.connections->sock_type, tmp.sock_type);
+    EXPECT_EQ(gateway.connections->port, tmp.port);
 }
 
 TEST(t_dlt_gateway_store_connection, nullpointer)
 {
     // NULL-Pointer, expect -1
+    DltGateway gateway;
+
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_store_connection(NULL , NULL, 0));
+    EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_store_connection(&gateway , NULL, 0));
 }
 
 /* Begin Method: dlt_gateway::t_dlt_gateway_check_ip*/
@@ -200,6 +183,7 @@ TEST(t_dlt_gateway_check_send_serial, normal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "134dltgatway";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_send_serial(con, value));
 }
 
@@ -209,14 +193,29 @@ TEST(t_dlt_gateway_check_send_serial, nullpointer)
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_send_serial(NULL,NULL));
 }
 
+/* Begin Method: dlt_gateway::t_dlt_gateway_allocate_control_messages*/
+TEST(t_dlt_gateway_allocate_control_messages, normal)
+{
+    DltGatewayConnection tmp;
+    DltGatewayConnection *con;
+    tmp.p_control_msgs = NULL;
+    con = &tmp;
+    EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_allocate_control_messages(con));
+}
+
+TEST(t_dlt_gateway_allocate_control_messages, nullpointer)
+{
+    EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_allocate_control_messages(NULL));
+}
+
 /* Begin Method: dlt_gateway::t_dlt_gateway_check_control_messages*/
 TEST(t_dlt_gateway_check_control_messages, normal)
 {
     DltGatewayConnection tmp;
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "1,2,3,4,5";
+    tmp.p_control_msgs = NULL;
     con = &tmp;
-    con->control_msgs[0] = DLT_SERVICE_ID_LAST_ENTRY;
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_control_messages(con, value));
 }
 
@@ -226,6 +225,22 @@ TEST(t_dlt_gateway_check_control_messages, nullpointer)
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_control_messages(NULL,NULL));
 }
 
+/* Begin Method: dlt_gateway::t_dlt_gateway_check_periodic_control_messages*/
+TEST(t_dlt_gateway_check_periodic_control_messages, normal)
+{
+    DltGatewayConnection tmp;
+    DltGatewayConnection *con;
+    char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "1:5,2:10";
+    tmp.p_control_msgs = NULL;
+    con = &tmp;
+    EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_periodic_control_messages(con, value));
+}
+
+TEST(t_dlt_gateway_check_periodic_control_messages, nullpointer)
+{
+    EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_periodic_control_messages(NULL,NULL));
+}
+
 /* Begin Method: dlt_gateway::t_dlt_gateway_check_port*/
 TEST(t_dlt_gateway_check_port, normal)
 {
@@ -233,6 +248,7 @@ TEST(t_dlt_gateway_check_port, normal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "3490";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_port(con, value));
 }
 
@@ -242,6 +258,7 @@ TEST(t_dlt_gateway_check_port, abnormal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "9999999999";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_port(con, value));
 }
 
@@ -258,6 +275,7 @@ TEST(t_dlt_gateway_check_ecu, normal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "ECU2";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_ecu(con, value));
 }
 
@@ -274,6 +292,7 @@ TEST(t_dlt_gateway_check_connect_trigger, normal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "OnStartup";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_connect_trigger(con, value));
 }
 
@@ -283,6 +302,7 @@ TEST(t_dlt_gateway_check_connect_trigger, abnormal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "wrong_parameter";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_connect_trigger(con, value));
 }
 
@@ -299,6 +319,7 @@ TEST(t_dlt_gateway_check_timeout, normal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "10";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_check_timeout(con, value));
 }
 
@@ -308,6 +329,7 @@ TEST(t_dlt_gateway_check_timeout, abnormal)
     DltGatewayConnection *con;
     char value[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "0";
     con = &tmp;
+
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_check_timeout(con, value));
 }
 
@@ -325,7 +347,9 @@ TEST(t_dlt_gateway_establish_connections, normal)
     DltGatewayConnection connections;
     gateway->num_connections = 1;
     gateway->connections = &connections;
-    gateway->connections->status = DLT_GATEWAY_CONNECTED;
+    gateway->connections->status = DLT_GATEWAY_INITIALIZED;
+    gateway->connections->trigger = DLT_GATEWAY_ON_STARTUP;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_establish_connections(gateway, &daemon_local, 0));
 }
 
@@ -348,6 +372,7 @@ TEST(t_dlt_gateway_get_connection_receiver, normal)
     gateway.connections->client.receiver.fd = 12;
     gateway.connections->status = DLT_GATEWAY_CONNECTED;
     ret = dlt_gateway_get_connection_receiver(&gateway, fd);
+
     EXPECT_EQ(12, ret->fd);
 }
 
@@ -362,6 +387,7 @@ TEST(t_dlt_gateway_get_connection_receiver, abnormal)
     gateway.connections->client.sock = fd;
     gateway.connections->client.receiver.fd = 12;
     ret = dlt_gateway_get_connection_receiver(&gateway, fd);
+
     EXPECT_EQ(NULL, ret);
 }
 
@@ -370,7 +396,118 @@ TEST(t_dlt_gateway_get_connection_receiver, nullpointer)
     // NULL-Pointer, expect -1
     DltReceiver *ret;
     ret = dlt_gateway_get_connection_receiver(NULL, 0);
+
     EXPECT_EQ(NULL, ret);
+}
+
+/* Begin Method: dlt_gateway::t_dlt_gateway_parse_get_log_info*/
+TEST(t_dlt_gateway_parse_get_log_info, normal)
+{
+    int32_t len;
+    DltDaemon daemon;
+    DltGateway gateway;
+    DltMessage msg;
+    char ecuid[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "ECU2";
+    uint32_t sid = DLT_SERVICE_ID_GET_LOG_INFO;
+    uint8_t status = 7;
+    uint16_t count_app_ids = 1;
+    uint16_t count_context_ids = 1;
+    const char *apid = "LOG";
+    const char *ctid = "TEST";
+    const char *com = "remo";
+    char app_description[] = "Test Application for Logging";
+    char context_description[] = "Test Context for Logging";
+    uint16_t len_app = 0;
+    uint16_t len_con = 0;
+    int8_t log_level = -1;
+    int8_t trace_status = -1;;
+    int offset = 0;
+    memset(&daemon, 0, sizeof(DltDaemon));
+    dlt_set_id(daemon.ecuid, ecuid);
+    EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
+    EXPECT_STREQ(daemon.ecuid, daemon.user_list[0].ecu);
+
+    /* create response message */
+    msg.datasize = sizeof(DltServiceGetLogInfoResponse) +
+                   sizeof(AppIDsType) +
+                   sizeof(ContextIDsInfoType);
+    msg.databuffer = (uint8_t *) malloc(msg.datasize);
+    msg.databuffersize = msg.datasize;
+    memset(msg.databuffer, 0, msg.datasize);
+
+    memcpy(msg.databuffer, &sid, sizeof(uint32_t));
+    offset += sizeof(uint32_t);
+
+    memcpy(msg.databuffer + offset, &status, sizeof(int8_t));
+    offset += sizeof(int8_t);
+
+    memcpy(msg.databuffer + offset, &count_app_ids, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+
+    dlt_set_id((char*)(msg.databuffer + offset), apid);
+    offset += sizeof(ID4);
+
+    memcpy(msg.databuffer + offset, &count_context_ids, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+
+    dlt_set_id((char*)(msg.databuffer + offset), ctid);
+    offset += sizeof(ID4);
+
+    memcpy(msg.databuffer + offset, &log_level, sizeof(int8_t));
+    offset += sizeof(int8_t);
+
+    memcpy(msg.databuffer + offset, &trace_status, sizeof(int8_t));
+    offset += sizeof(int8_t);
+
+    len_con = strlen(context_description);
+    memcpy(msg.databuffer + offset, &len_con, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+
+    memcpy(msg.databuffer + offset, context_description, strlen(context_description));
+    offset += strlen(context_description);
+
+    len_app = strlen(app_description);
+    memcpy(msg.databuffer + offset, &len_app, sizeof(uint16_t));
+    offset += sizeof(uint16_t);
+
+    memcpy(msg.databuffer + offset, app_description, strlen(app_description));
+    offset += strlen(app_description);
+
+    dlt_set_id((char*)(msg.databuffer + offset), com);
+
+    msg.storageheader = (DltStorageHeader*)msg.headerbuffer;
+    dlt_set_storageheader(msg.storageheader, "");
+
+    msg.standardheader = (DltStandardHeader*)(msg.headerbuffer + sizeof(DltStorageHeader));
+    msg.standardheader->htyp = DLT_HTYP_WEID | DLT_HTYP_WTMS | DLT_HTYP_UEH | DLT_HTYP_PROTOCOL_VERSION1 ;
+    msg.standardheader->mcnt = 0;
+
+    dlt_set_id(msg.headerextra.ecu, ecuid);
+    msg.headerextra.tmsp = dlt_uptime();
+    dlt_message_set_extraparameters(&msg, 0);
+
+    msg.extendedheader = (DltExtendedHeader*)(msg.headerbuffer +
+                         sizeof(DltStorageHeader) +
+                         sizeof(DltStandardHeader) +
+                         DLT_STANDARD_HEADER_EXTRA_SIZE(msg.standardheader->htyp) );
+    msg.extendedheader->msin = DLT_MSIN_CONTROL_RESPONSE;
+    msg.extendedheader->noar = 1;
+    dlt_set_id(msg.extendedheader->apid, "");
+    dlt_set_id(msg.extendedheader->ctid, "");
+
+    msg.headersize = sizeof(DltStorageHeader) +
+                     sizeof(DltStandardHeader) +
+                     sizeof(DltExtendedHeader) +
+                     DLT_STANDARD_HEADER_EXTRA_SIZE(msg.standardheader->htyp);
+    len = msg.headersize - sizeof(DltStorageHeader) + msg.datasize;
+    msg.standardheader->len = DLT_HTOBE_16(len);
+
+    EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_parse_get_log_info(&daemon, ecuid, &msg, 0));
+}
+
+TEST(t_dlt_gateway_parse_get_log_info, nullpointer)
+{
+    EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_parse_get_log_info(NULL, NULL, NULL, 0));
 }
 
 /* Begin Method: dlt_gateway::t_dlt_gateway_process_passive_node_messages*/
@@ -380,9 +517,14 @@ TEST(t_dlt_gateway_process_passive_node_messages, normal)
     DltDaemonLocal daemon_local;
     DltReceiver receiver;
     DltGatewayConnection connections;
+    memset(&daemon, 0, sizeof(DltDaemon));
+    memset(&daemon_local, 0, sizeof(DltDaemonLocal));
+    memset(&receiver, 0, sizeof(DltReceiver));
+    memset(&connections, 0, sizeof(DltGatewayConnection));
     daemon_local.pGateway.connections = &connections;
     daemon_local.pGateway.num_connections = 1;
     daemon_local.pGateway.connections->status = DLT_GATEWAY_CONNECTED;
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_process_passive_node_messages(&daemon,&daemon_local,&receiver,1));
 }
 
@@ -404,13 +546,13 @@ TEST(t_dlt_gateway_process_gateway_timer, normal)
     daemon_local.pGateway.connections = &connections;
     daemon_local.pGateway.num_connections = 1;
     DltLogStorage storage_handle;
-    daemon_local.pGateway.connections->status = DLT_GATEWAY_CONNECTED;
+    daemon_local.pGateway.connections->status = DLT_GATEWAY_INITIALIZED;
+    daemon_local.pGateway.connections->trigger = DLT_GATEWAY_ON_STARTUP;
 
     daemon_local.pEvent.connections = &connections1;
     daemon_local.pEvent.connections->receiver = &receiver;
     daemon.ECUVersionString = ECUVersionString;
     daemon.storage_handle = &storage_handle;
-
     daemon_local.pEvent.connections->receiver->fd = -1;
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_process_gateway_timer(&daemon,&daemon_local,daemon_local.pEvent.connections->receiver,1));
@@ -427,12 +569,12 @@ TEST(t_dlt_gateway_process_on_demand_request, normal)
 {
     char node_id[DLT_ID_SIZE] = "123";
     uint32_t connection_status = 1;
-
     DltDaemonLocal daemon_local;
     DltGatewayConnection connections;
     daemon_local.pGateway.connections = &connections;
     daemon_local.pGateway.num_connections = 1;
     connections.status = DLT_GATEWAY_CONNECTED;
+    connections.trigger = DLT_GATEWAY_ON_STARTUP;
     connections.ecuid = node_id;
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_process_on_demand_request(&daemon_local.pGateway,
@@ -446,7 +588,6 @@ TEST(t_dlt_gateway_process_on_demand_request, abnormal)
 {
     char node_id[DLT_ID_SIZE] = "123";
     uint32_t connection_status = 1;
-
     DltDaemonLocal daemon_local;
     DltGatewayConnection connections;
     daemon_local.pGateway.connections = &connections;
@@ -491,7 +632,6 @@ TEST(t_dlt_gateway_check_param, normal)
 TEST(t_dlt_gateway_check_param, abnormal)
 {
     char value_1[DLT_CONFIG_FILE_ENTRY_MAX_LEN] = "10.11.22.33";
-
     DltGateway gateway;
     DltGatewayConnection tmp;
     gateway.connections = &tmp;
@@ -516,7 +656,8 @@ TEST(t_dlt_gateway_configure, Normal)
     gateway.connections = &tmp;
     gateway.num_connections = 1;
     char gatewayConfigFile[DLT_DAEMON_FLAG_MAX];
-    strncpy(gatewayConfigFile, DLT_GATEWAY_CONFIG_PATH, DLT_DAEMON_FLAG_MAX - 1);
+    strncpy(gatewayConfigFile, "/tmp/dlt_gateway.conf", DLT_DAEMON_FLAG_MAX - 1);
+
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_configure(&gateway, gatewayConfigFile, 0));
 }
 
@@ -526,49 +667,10 @@ TEST(t_dlt_gateway_configure, nullpointer)
     EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_configure(NULL, NULL, 0));
 }
 
-/* Begin Method: dlt_gateway::t_dlt_gateway_forward_control_message*/
-TEST(t_dlt_gateway_forward_control_message, normal)
-{
-    int ret = 0;
-    char ecu[DLT_ID_SIZE] = {'E', 'C', 'U', '1'};
-    DltDaemonLocal daemon_local;
-    DltGatewayConnection connections;
-    DltConnection connections1;
-    DltReceiver receiver1;
-
-    daemon_local.pGateway.connections = &connections;
-    daemon_local.pEvent.connections = &connections1;
-    daemon_local.pEvent.connections->receiver = &receiver1;
-    daemon_local.pEvent.connections->receiver->fd = 1;
-    daemon_local.pEvent.connections->next = NULL;
-    daemon_local.pGateway.num_connections = 1;
-    daemon_local.pEvent.connections->type = DLT_CONNECTION_CLIENT_MSG_TCP;
-
-    DltMessage msg;
-    memset(daemon_local.flags.gatewayConfigFile,0,DLT_DAEMON_FLAG_MAX);
-    strncpy(daemon_local.flags.gatewayConfigFile, "/tmp/dlt_gateway.conf", DLT_DAEMON_FLAG_MAX - 1);
-
-    ret = dlt_gateway_init(&daemon_local, 0);
-    EXPECT_EQ(DLT_RETURN_OK, ret);
-
-    ret = dlt_gateway_forward_control_message(&daemon_local.pGateway,
-                                                       &daemon_local,
-                                                       &msg,
-                                                       ecu,
-                                                       0);
-    EXPECT_EQ(DLT_RETURN_OK, ret);
-}
-
-TEST(t_dlt_gateway_forward_control_message, nullpointer)
-{
-    // NULL-Pointer, expect -1
-    EXPECT_EQ(DLT_RETURN_ERROR, dlt_gateway_forward_control_message(NULL, NULL, NULL, NULL, 0));
-}
-
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
 //    ::testing::FLAGS_gtest_break_on_failure = true;
-//    ::testing::FLAGS_gtest_filter = "t_dlt_gateway_forward_control_message*";
+//    ::testing::FLAGS_gtest_filter = "t_dlt_gateway_process_passive_node_messages*";
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
 -Support to send and parse periodic control messages
 -add application/contexts to passive ECU list
 -Refactor dlt_gateway_send_control_message
 -Gateway issues with corrupted data and on demand connection
 -DLT Service ID Enum instead of defines
 -dlt-control: update get log info
 -dlt-client: logging: Extended the receiver buffer size
 -Unit Test update

Signed-off-by: Saya Sugiura <ssugiura@jp.adit-jv.com>
Signed-off-by: Christoph Lipka <clipka@jp.adit-jv.com>
Signed-off-by: S. Hameed <shameed@jp.adit-jv.com>
Signed-off-by: ManikandanC <Manikandan.Chockalingam@in.bosch.com>