### PR TITLE
Use poll in the dlt-daemon for POSIX compliance

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -76,7 +76,11 @@
 */
 
 #include <stdio.h>
+#ifdef __linux__
 #include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
 
 #if !defined(_MSC_VER)
 #include <unistd.h>

--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -500,6 +500,13 @@ DltReturnValue dlt_register_app(const char *appid, const char * description);
 DltReturnValue dlt_unregister_app(void);
 
 /**
+ * Unregister an application in the daemon and also flushes the buffered logs.
+ * This function has to be called when finishing using an application.
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_unregister_app_flush_buffered_logs(void);
+
+/**
  * Register a context in the daemon.
  * This function has to be called before first usage of the context.
  * @param handle pointer to an object containing information about one special logging context

--- a/include/dlt/dlt_user_macros.h
+++ b/include/dlt/dlt_user_macros.h
@@ -121,6 +121,12 @@
     (void)dlt_unregister_app();} while(0)
 
 /**
+ * Unregister application and flush the logs buffered in startup buffer if any.
+ */
+#define DLT_UNREGISTER_APP_FLUSH_BUFFERED_LOGS() do{\
+    (void)dlt_unregister_app_flush_buffered_logs();} while(0)
+
+/**
  * Register context (with default log level and default trace status)
  * @param CONTEXT object containing information about one special logging context
  * @param CONTEXTID context id with maximal four characters

--- a/src/adaptor/dlt-adaptor-stdin.c
+++ b/src/adaptor/dlt-adaptor-stdin.c
@@ -92,11 +92,12 @@ int main(int argc, char* argv[])
     char version[255];
     int timeout = -1;
     int verbosity = DLT_LOG_INFO;
+    int bflag = 0;
 
     dlt_set_id(apid, PS_DLT_APP);
     dlt_set_id(ctid, PS_DLT_CONTEXT);
 
-    while ((opt = getopt(argc, argv, "a:c:ht:v:")) != -1)
+    while ((opt = getopt(argc, argv, "a:c:bht:v:")) != -1)
     {
         switch (opt)
         {
@@ -108,6 +109,11 @@ int main(int argc, char* argv[])
         case 'c':
         {
             dlt_set_id(ctid,optarg);
+            break;
+        }
+        case 'b':
+        {
+            bflag = 1;
             break;
         }
         case 't':
@@ -125,6 +131,7 @@ int main(int argc, char* argv[])
             printf("Options:\n");
             printf("  -a apid      - Set application id to apid (default: SINA)\n");
             printf("  -c ctid      - Set context id to ctid (default: SINC)\n");
+            printf("  -b           - Flush buffered logs before unregistering app\n");
             printf("  -t timeout   - Set timeout when sending messages at exit, in ms (Default: 10000 = 10sec)\n");
             printf("  -v verbosity level - Set verbosity level (Default: INFO, values: FATAL ERROR WARN INFO DEBUG VERBOSE)\n");
             printf("  -h           - This help\n");
@@ -194,7 +201,15 @@ int main(int argc, char* argv[])
     }
 
     DLT_UNREGISTER_CONTEXT(mycontext);
-    DLT_UNREGISTER_APP();
+
+    if (bflag == 1)
+    {
+        DLT_UNREGISTER_APP_FLUSH_BUFFERED_LOGS();
+    }
+    else
+    {
+        DLT_UNREGISTER_APP();
+    }
 
     return 0;
 }

--- a/src/console/logstorage/CMakeLists.txt
+++ b/src/console/logstorage/CMakeLists.txt
@@ -16,23 +16,25 @@
 #######
 add_definitions( -Werror )
 
-if(WITH_DLT_LOGSTORAGE_CTRL_UDEV AND WITH_DLT_LOGSTORAGE_CTRL_PROP)
- set(dlt_logstorage_ctrl_SRCS dlt-logstorage-ctrl.c dlt-logstorage-common.c dlt-logstorage-prop.c dlt-logstorage-udev.c dlt-logstorage-list.c)
-elseif(WITH_DLT_LOGSTORAGE_CTRL_PROP)
- set(dlt_logstorage_ctrl_SRCS dlt-logstorage-ctrl.c dlt-logstorage-common.c dlt-logstorage-prop.c dlt-logstorage-list.c)
-elseif(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
- set(dlt_logstorage_ctrl_SRCS dlt-logstorage-ctrl.c dlt-logstorage-common.c dlt-logstorage-udev.c dlt-logstorage-list.c)
-else(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
- set(dlt_logstorage_ctrl_SRCS dlt-logstorage-ctrl.c dlt-logstorage-common.c dlt-logstorage-list.c)
-endif(WITH_DLT_LOGSTORAGE_CTRL_UDEV AND WITH_DLT_LOGSTORAGE_CTRL_PROP)
-
-add_executable(dlt-logstorage-ctrl ${dlt_logstorage_ctrl_SRCS} ${dlt_control_common_SRCS} ${dlt_most_SRCS} ${CMAKE_SOURCE_DIR}/systemd/3rdparty/sd-daemon.c )
+set(dlt_logstorage_ctrl_SRCS dlt-logstorage-ctrl.c dlt-logstorage-common.c dlt-logstorage-list.c)
 
 if(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
- target_link_libraries(dlt-logstorage-ctrl dlt udev ${EXPAT_LIBRARIES})
-else(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
- target_link_libraries(dlt-logstorage-ctrl dlt ${EXPAT_LIBRARIES})
+ set(dlt_logstorage_ctrl_SRCS ${dlt_logstorage_ctrl_SRCS} dlt-logstorage-udev.c)
 endif(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
+
+if(WITH_SYSTEMD)
+ set(dlt_logstorage_ctrl_SRCS ${dlt_logstorage_ctrl_SRCS} ${CMAKE_SOURCE_DIR}/systemd/3rdparty/sd-daemon.c)
+endif(WITH_SYSTEMD)
+
+add_executable(dlt-logstorage-ctrl ${dlt_logstorage_ctrl_SRCS} ${dlt_control_common_SRCS} ${dlt_most_SRCS})
+
+set(DLT_LOGSTORAGE_LIBRARIES dlt-logstorage-ctrl dlt ${EXPAT_LIBRARIES})
+
+if(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
+ set(DLT_LOGSTORAGE_LIBRARIES ${DLT_LOGSTORAGE_LIBRARIES} udev)
+endif(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
+
+target_link_libraries(${DLT_LOGSTORAGE_LIBRARIES})
 
 set_target_properties(dlt-logstorage-ctrl PROPERTIES LINKER_LANGUAGE C)
 

--- a/src/console/logstorage/dlt-logstorage-list.c
+++ b/src/console/logstorage/dlt-logstorage-list.c
@@ -143,6 +143,7 @@ static struct LogstorageDeviceInfo *logstorage_find_dev_info(const char *node)
 int logstorage_store_dev_info(const char *node, const char *path)
 {
     struct LogstorageDeviceInfo *ptr = NULL;
+    size_t path_len = 0;
 
     if ((node == NULL) || (path == NULL))
     {
@@ -166,7 +167,21 @@ int logstorage_store_dev_info(const char *node, const char *path)
     }
 
     ptr->dev_node = strdup(node);
-    ptr->mnt_point = strndup(path, DLT_MOUNT_PATH_MAX);
+    path_len = strlen(path);
+    if (path_len >DLT_MOUNT_PATH_MAX)
+    {
+        path_len = (size_t)DLT_MOUNT_PATH_MAX;
+    }
+    ptr->mnt_point = (char *)calloc(1, path_len + 1);
+
+    if (ptr->mnt_point == NULL)
+    {
+        pr_error("memory allocation failed for mnt_point\n");
+        return -1;
+    }
+
+    ptr->mnt_point[path_len] = '\0';
+    memcpy(ptr->mnt_point, path, path_len);
 
     /* Put it on head */
     ptr->next = g_info;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -20,9 +20,22 @@ if(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
     message( STATUS "Added ${systemd_SRCS} to dlt-daemon")
 endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
 
-set(dlt_daemon_SRCS dlt-daemon.c dlt_daemon_common.c dlt_daemon_connection.c dlt_daemon_event_handler.c ${CMAKE_SOURCE_DIR}/src/gateway/dlt_gateway.c dlt_daemon_socket.c dlt_daemon_unix_socket.c dlt_daemon_serial.c dlt_daemon_client.c dlt_daemon_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_offline_trace.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/lib/dlt_client.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_config_file_parser.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+set(dlt_daemon_SRCS dlt-daemon.c dlt_daemon_common.c dlt_daemon_connection.c dlt_daemon_event_handler.c ${CMAKE_SOURCE_DIR}/src/gateway/dlt_gateway.c dlt_daemon_socket.c dlt_daemon_unix_socket.c dlt_daemon_serial.c dlt_daemon_client.c dlt_daemon_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_offline_trace.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/lib/dlt_client.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_config_file_parser.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+
+if(WITH_DLT_SHM_ENABLE)
+    set(dlt_daemon_SRCS ${dlt_daemon_SRCS} ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c)
+endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(RT_LIBRARY rt)
+    set(SOCKET_LIBRARY "")
+else()
+    set(RT_LIBRARY "")
+    set(SOCKET_LIBRARY socket)
+endif()
+
 add_executable(dlt-daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
-target_link_libraries(dlt-daemon rt ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(dlt-daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS dlt-daemon
 	RUNTIME DESTINATION bin
@@ -33,7 +46,7 @@ install(TARGETS dlt-daemon
 
 if (WITH_DLT_UNIT_TESTS)
     add_library(dlt_daemon ${dlt_daemon_SRCS})
-    target_link_libraries(dlt_daemon rt ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(dlt_daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
     install(TARGETS dlt_daemon
             RUNTIME DESTINATION bin
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1049,7 +1049,7 @@ static int dlt_daemon_init_serial(DltDaemonLocal *daemon_local)
     return dlt_connection_create(daemon_local,
                                  &daemon_local->pEvent,
                                  fd,
-                                 EPOLLIN,
+                                 POLLIN,
                                  DLT_CONNECTION_CLIENT_MSG_SERIAL);
 }
 
@@ -1121,7 +1121,7 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
     return dlt_connection_create(daemon_local,
                                  &daemon_local->pEvent,
                                  fd,
-                                 EPOLLIN,
+                                 POLLIN,
                                  DLT_CONNECTION_APP_MSG);
 }
 #endif
@@ -1159,7 +1159,7 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
         if (dlt_connection_create(daemon_local,
                                   &daemon_local->pEvent,
                                   fd,
-                                  EPOLLIN,
+                                  POLLIN,
                                   DLT_CONNECTION_APP_CONNECT))
         {
             dlt_log(LOG_CRIT, "Could not initialize app socket.\n");
@@ -1186,7 +1186,7 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
         if (dlt_connection_create(daemon_local,
                                   &daemon_local->pEvent,
                                   fd,
-                                  EPOLLIN,
+                                  POLLIN,
                                   DLT_CONNECTION_CLIENT_CONNECT))
         {
             dlt_log(LOG_ERR,"Could not initialize main socket.\n");
@@ -1211,7 +1211,7 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
         if (dlt_connection_create(daemon_local,
                                   &daemon_local->pEvent,
                                   fd,
-                                  EPOLLIN,
+                                  POLLIN,
                                   DLT_CONNECTION_CONTROL_CONNECT))
         {
             dlt_log(LOG_ERR, "Could not initialize control socket.\n");
@@ -1630,7 +1630,7 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
     if (dlt_connection_create(daemon_local,
                              &daemon_local->pEvent,
                              in_sock,
-                             EPOLLIN,
+                             POLLIN,
                              DLT_CONNECTION_CLIENT_MSG_TCP))
     {
         dlt_log(LOG_ERR, "Failed to register new client. \n");
@@ -1901,7 +1901,7 @@ int dlt_daemon_process_control_connect(
     if (dlt_connection_create(daemon_local,
                              &daemon_local->pEvent,
                              in_sock,
-                             EPOLLIN,
+                             POLLIN,
                              DLT_CONNECTION_CONTROL_MSG))
     {
         dlt_log(LOG_ERR, "Failed to register new client. \n");
@@ -1956,7 +1956,7 @@ int dlt_daemon_process_app_connect(
     if (dlt_connection_create(daemon_local,
                              &daemon_local->pEvent,
                              in_sock,
-                             EPOLLIN,
+                             POLLIN,
                              DLT_CONNECTION_APP_MSG))
     {
         dlt_log(LOG_ERR, "Failed to register new application. \n");
@@ -2003,7 +2003,7 @@ int dlt_daemon_process_control_messages(
         /* FIXME: Why the hell do we need to close the socket
          * on control message reception ??
          */
-        //return 0;
+        return 0;
     }
 
     /* Process all received messages */
@@ -3422,7 +3422,7 @@ int create_timer_fd(DltDaemonLocal *daemon_local,
     return dlt_connection_create(daemon_local,
                                  &daemon_local->pEvent,
                                  local_fd,
-                                 EPOLLIN,
+                                 POLLIN,
                                  dlt_timer_conn_types[timer_id]);
 }
 

--- a/src/daemon/dlt_daemon_connection.c
+++ b/src/daemon/dlt_daemon_connection.c
@@ -34,7 +34,7 @@
 #include <unistd.h>
 
 #include <sys/socket.h>
-#include <sys/syslog.h>
+#include <syslog.h>
 #include <sys/types.h>
 
 #include "dlt_daemon_connection_types.h"
@@ -331,7 +331,7 @@ void dlt_connection_destroy(DltConnection *to_destroy)
     to_destroy->id = 0;
     close(to_destroy->receiver->fd);
     dlt_connection_destroy_receiver(to_destroy);
-    /* connection pointer might be in epoll queue and used even after destroying
+    /* connection pointer might be in poll queue and used even after destroying
      * it. To make sure it is not used anymore, connection type is invalidated */
     to_destroy->type = DLT_CONNECTION_TYPE_MAX;
     free(to_destroy);
@@ -370,7 +370,7 @@ int dlt_connection_create(DltDaemonLocal *daemon_local,
         /* No need for the same client to be registered twice
          * for the same event.
          * TODO: If another mask can be expected,
-         * we need it to update the epoll event here.
+         * we need it to update the poll event here.
          */
         return 0;
     }

--- a/src/daemon/dlt_daemon_connection_types.h
+++ b/src/daemon/dlt_daemon_connection_types.h
@@ -33,8 +33,8 @@
 
 typedef enum {
     UNDEFINED, /* Undefined status */
-    INACTIVE,  /* Connection is inactive, excluded from epoll handling */
-    ACTIVE,    /* Connection is actively handled by epoll */
+    INACTIVE,  /* Connection is inactive, excluded from poll handling */
+    ACTIVE,    /* Connection is actively handled by poll */
     DEACTIVATE,/* Request for deactivation of the connection */
     ACTIVATE   /* Request for activation of the connection */
 } DltConnectionStatus;

--- a/src/daemon/dlt_daemon_event_handler.h
+++ b/src/daemon/dlt_daemon_event_handler.h
@@ -27,7 +27,7 @@
  * \file dlt_daemon_event_handler.h
  */
 
-#include <sys/epoll.h>
+#include <sys/poll.h>
 
 #include "dlt_daemon_connection_types.h"
 #include "dlt_daemon_event_handler_types.h"

--- a/src/daemon/dlt_daemon_event_handler_types.h
+++ b/src/daemon/dlt_daemon_event_handler_types.h
@@ -27,7 +27,7 @@
  * \file dlt_daemon_event_handler_types.h
  */
 
-#include <sys/epoll.h>
+#include <sys/poll.h>
 
 #include "dlt_daemon_connection_types.h"
 
@@ -50,10 +50,10 @@ typedef enum {
     DLT_TIMER_UNKNOWN
 } DltTimers;
 
-#define DLT_EPOLL_MAX_EVENTS 10
 typedef struct {
-    int epfd;
-    struct epoll_event events[DLT_EPOLL_MAX_EVENTS];
+    struct pollfd *pfd;
+    nfds_t nfds;
+    nfds_t max_nfds;
     DltConnection *connections;
 } DltEventHandler;
 

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -868,11 +868,11 @@ STATIC int dlt_gateway_add_to_event_loop(DltDaemonLocal *daemon_local,
     con->timeout_cnt = 0;
     con->sendtime_cnt = 0;
 
-    /* setup dlt connection and add to epoll event loop here */
+    /* setup dlt connection and add to poll event loop here */
     if (dlt_connection_create(daemon_local,
                               &daemon_local->pEvent,
                               con->client.sock,
-                              EPOLLIN,
+                              POLLIN,
                               DLT_CONNECTION_GATEWAY) != 0)
     {
         dlt_log(LOG_ERR, "Gateway connection creation failed\n");
@@ -947,7 +947,7 @@ int dlt_gateway_establish_connections(DltGateway *gateway,
 
             if (ret == 0)
             {
-                /* setup dlt connection and add to epoll event loop here */
+                /* setup dlt connection and add to poll event loop here */
                 if (dlt_gateway_add_to_event_loop(daemon_local, con, verbose) != DLT_RETURN_OK)
                 {
                     dlt_log(LOG_ERR, "Gateway connection creation failed\n");
@@ -972,11 +972,11 @@ int dlt_gateway_establish_connections(DltGateway *gateway,
         else if ((con->status == DLT_GATEWAY_CONNECTED) &&
                  (con->trigger != DLT_GATEWAY_DISABLED))
         {
-            /* setup dlt connection and add to epoll event loop here */
+            /* setup dlt connection and add to poll event loop here */
             if (dlt_connection_create(daemon_local,
                                  &daemon_local->pEvent,
                                  con->client.sock,
-                                 EPOLLIN,
+                                 POLLIN,
                                  DLT_CONNECTION_GATEWAY) != 0)
             {
                 dlt_log(LOG_ERR, "Gateway connection creation failed\n");
@@ -1672,7 +1672,7 @@ int dlt_gateway_process_on_demand_request(DltGateway *gateway,
         {
             if (dlt_client_connect(&con->client, verbose) == 0)
             {
-                /* setup dlt connection and add to epoll event loop here */
+                /* setup dlt connection and add to poll event loop here */
                 if (dlt_gateway_add_to_event_loop(daemon_local, con, verbose) != DLT_RETURN_OK)
                 {
                     dlt_log(LOG_ERR, "Gateway connection creation failed\n");

--- a/src/gateway/dlt_gateway.h
+++ b/src/gateway/dlt_gateway.h
@@ -84,7 +84,7 @@ void dlt_gateway_deinit(DltGateway *g, int verbose);
  * on daemon startup and add this connections to the main event loop.
  *
  * TODO: This function is called during gateway initialization and in main loop
- *       whenever the epoll returns. This may need to be improved.
+ *       whenever the poll returns. This may need to be improved.
  *
  * @param g             DltGateway
  * @param daemon_local  DltDaemonLocal

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -15,10 +15,23 @@
 # @licence end@
 #######
 
-set(dlt_LIB_SRCS dlt_user dlt_client dlt_filetransfer dlt_env_ll ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+set(dlt_LIB_SRCS dlt_user dlt_client dlt_filetransfer dlt_env_ll ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+
+if(WITH_DLT_SHM_ENABLE)
+    set(dlt_LIB_SRCS ${dlt_LIB_SRCS} ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c)
+endif(WITH_DLT_SHM_ENABLE)
 
 add_library(dlt ${dlt_LIB_SRCS})
-target_link_libraries(dlt rt ${CMAKE_THREAD_LIBS_INIT})
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(RT_LIBRARY rt)
+    set(SOCKET_LIBRARY "")
+else()
+    set(RT_LIBRARY "")
+    set(SOCKET_LIBRARY socket)
+endif()
+
+target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
 set_target_properties(dlt PROPERTIES VERSION ${DLT_VERSION} SOVERSION ${DLT_MAJOR_VERSION})
 

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -3166,6 +3166,7 @@ speed_t dlt_convert_serial_speed(int baudrate)
         ret = B115200;
         break;
     }
+#ifdef __linux__
     case 230400:
     {
         ret = B230400;
@@ -3231,6 +3232,7 @@ speed_t dlt_convert_serial_speed(int baudrate)
         ret = B4000000;
         break;
     }
+#endif /* __linux__ */
     default:
     {
         ret = B115200;

--- a/src/tests/dlt-test-multi-process.c
+++ b/src/tests/dlt-test-multi-process.c
@@ -62,6 +62,10 @@
 #define MAX_PROCS 100
 #define MAX_THREADS 100
 
+#ifndef WAIT_ANY
+#define WAIT_ANY -1
+#endif
+
 // Structs
 typedef struct {
     int nmsgs;            // Number of messages to send


### PR DESCRIPTION
The poll system call is now used in the daemon to enable DLT use in
POSIX compliant systems. Also added introduced new unregister_app macro
to avoid missing of logs in startup buffer.

Signed-off-by: Frederic Berat <fberat@de.adit-jv.com>
Signed-off-by: ManikandanC <Manikandan.Chockalingam@in.bosch.com>
Signed-off-by: Saya Sugiura <ssugiura@jp.adit-jv.com>
Signed-off-by: S. Hameed <shameed@jp.adit-jv.com>