### PR TITLE
Pipe name to use APID instead of PID

### DIFF
--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -486,6 +486,8 @@ DltReturnValue dlt_user_trace_network_segmented(DltContext *handle,
  */
 DltReturnValue dlt_init();
 
+DltReturnValue dlt_init_with_appid();
+
 /**
  * Initialize the user lib writing only to file.
  * This function has to be called first, before using any DLT user lib functions.

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -505,9 +505,9 @@ DltDaemonApplication *dlt_daemon_application_add(DltDaemon *daemon,
 
             if (close(application->user_handle) < 0)
                 dlt_vlog(LOG_WARNING,
-                         "close() failed to %s/dltpipes/dlt%d, errno=%d (%s)!\n",
+                         "close() failed to %s/dltpipes/dlt%.4s, errno=%d (%s)!\n",
                          dltFifoBaseDir,
-                         pid,
+                         apid,
                          errno,
                          strerror(errno)); /* errno 2: ENOENT - No such file or directory */
 
@@ -524,9 +524,9 @@ DltDaemonApplication *dlt_daemon_application_add(DltDaemon *daemon,
 #else
         snprintf(filename,
                  DLT_DAEMON_COMMON_TEXTBUFSIZE,
-                 "%s/dltpipes/dlt%d",
+                 "%s/dltpipes/dlt%.4s",
                  dltFifoBaseDir,
-                 pid);
+                 apid);
 
         dlt_user_handle = open(filename, O_WRONLY | O_NONBLOCK);
 


### PR DESCRIPTION
Currently DLT library uses PID of the process as a part
of the pipe's name which is created in dltpipes folder.

This should be changed to support PID namespace which means
that PID of the process can't be part of the name. We propose to
use DLT APP ID as a replacement because that is always unique per
user (client).