### PR TITLE
Fixed memory leak when receiving network traces of 0xFFFF length

### DIFF
--- a/include/dlt/dlt_types.h
+++ b/include/dlt/dlt_types.h
@@ -158,7 +158,7 @@ typedef enum
     DLT_NW_TRACE_USER_DEFINED4 = 0x0C,
     DLT_NW_TRACE_USER_DEFINED5 = 0x0D,
     DLT_NW_TRACE_USER_DEFINED6 = 0x0E,
-    DLT_NW_TRACE_USER_DEFINED7 = 0x0F,
+    DLT_NW_TRACE_RESEND = 0x0F,             /**< Mark a resend */
     DLT_NW_TRACE_MAX                        /**< maximum value, used for range check */
 } DltNetworkTraceType;
 

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -2949,7 +2949,8 @@ void dlt_user_trace_network_segmented_thread(void *unused)
         }
 
         /* Indicator just to try to flush the buffer */
-        if (data->payload_len == DLT_DELAYED_RESEND_INDICATOR_PATTERN) {
+        /* DLT_NW_TRACE_RESEND custom type is used to mark a resend */
+        if(data->nw_trace_type == DLT_NW_TRACE_RESEND) {
             /* Sleep 100ms, to allow other process to read FIFO */
             usleep(100 * 1000);
 
@@ -3523,7 +3524,8 @@ DltReturnValue dlt_user_queue_resend(void)
     if (resend_data == NULL)
         return DLT_RETURN_ERROR;
 
-    resend_data->payload_len = DLT_DELAYED_RESEND_INDICATOR_PATTERN;
+    /* DLT_NW_TRACE_RESEND custom type is used to mark a resend */
+    resend_data->nw_trace_type = DLT_NW_TRACE_RESEND;
 
     /* Open queue if it is not open */
     if (dlt_init_message_queue() < DLT_RETURN_OK) {


### PR DESCRIPTION
0xFFFF was used as a magic number in the length field of a network
message in order to trigger a resend. DLT library will now use the
nw_trace_type field and a custom type to do this, thus assuring no
external client of the library can reach this
value(DLT_NW_TRACE_USER_DEFINED7).