### PR TITLE
Size of Resend buffer less than or equal to DLT_USER_BUF_MAX_SIZE res…

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -98,6 +98,9 @@ static int atexit_registered = 0;
 /* used to disallow DLT usage in fork() child */
 static int g_dlt_is_child = 0;
 
+/*Max DLT message size is 1390 bytes plus some extra header space  to accomidate the resend buffer*/
+#define DLT_USER_EXTRA_BUFF_SIZE 100
+
 /* Segmented Network Trace */
 #define DLT_MAX_TRACE_SEGMENT_SIZE 1024
 #define DLT_MESSAGE_QUEUE_NAME "/dlt_message_queue"
@@ -665,7 +668,7 @@ DltReturnValue dlt_init_common(void)
     }
 
     if (dlt_user.resend_buffer == NULL) {
-        dlt_user.resend_buffer = calloc(sizeof(unsigned char), (dlt_user.log_buf_len + 100));
+        dlt_user.resend_buffer = calloc(sizeof(unsigned char), (dlt_user.log_buf_len + DLT_USER_EXTRA_BUFF_SIZE));
 
         if (dlt_user.resend_buffer == NULL) {
             dlt_user_initialised = false;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -665,7 +665,7 @@ DltReturnValue dlt_init_common(void)
     }
 
     if (dlt_user.resend_buffer == NULL) {
-        dlt_user.resend_buffer = calloc(sizeof(unsigned char), dlt_user.log_buf_len);
+        dlt_user.resend_buffer = calloc(sizeof(unsigned char), (dlt_user.log_buf_len + 100));
 
         if (dlt_user.resend_buffer == NULL) {
             dlt_user_initialised = false;


### PR DESCRIPTION
…ults in Memory corruption.

As older version of DLT DLT_USER_RESENDBUF_MAX_SIZE is  [DLT_USER_BUF_MAX_SIZE + 100] which contains space for extra headers,  where as in DLT 2.18 the resend buffer is bound to DLT_USER_BUF_MAX_SIZE which results in memory corruption in dlt_buffer_read_block  when the size of the data is more than DLT_USER_BUF_MAX_SIZE.

Reason for not using "DLT_USER_RESENDBUF_MAX_SIZE" during dynamic memory allocation of resend buffer is as user has got the feasibility to alter the DLT_USER_BUF_MAX_SIZE using the environmental variables the resend buffer in any scenario to be greater then dlt_user.log_buf_len to accommodate the extra headers.