### PR TITLE
dlt-control: Wait until send buffer is empty before exiting

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -2917,9 +2917,24 @@ void dlt_user_trace_network_segmented_thread(void *unused)
     prctl(PR_SET_NAME, "dlt_segmented", 0, 0, 0);
 #endif
 
+    int count = 0;
     s_segmented_data *data;
+    struct timespec reattach_interval;
+
+    reattach_interval.tv_sec = 0;
+    reattach_interval.tv_nsec = DLT_USER_REATTACH_INTERVAL;
 
     while (1) {
+        // Normally reattaching to dlt-daemon is triggered when app tries to output log.
+        // Even if the app outputs log only before starting up of the dlt-daemon,
+        // this retry loop helps reattaching.
+        while ((dlt_user.dlt_log_handle < 0) && (count < DLT_USER_REATTACH_MAX_COUNT))
+        {
+            dlt_user_log_reattach_to_daemon();
+            nanosleep(&reattach_interval, NULL);
+            count++;
+        }
+
         /* Wait until message queue is initialized */
         dlt_lock_mutex(&mq_mutex);
 

--- a/src/lib/dlt_user_cfg.h
+++ b/src/lib/dlt_user_cfg.h
@@ -143,6 +143,13 @@
 /* Retry interval for mq error in usec */
 #define DLT_USER_MQ_ERROR_RETRY_INTERVAL 100000
 
+/* Maximum retry count for reattach to dlt-daemon
+   (Default: 30 count  * 500000 usec = 15s) */
+#define DLT_USER_REATTACH_MAX_COUNT 30
+
+/* Retry interval for reattach to dlt-daemon [nsec] (1000000 nsec = 1000 usec = 1ms) */
+#define DLT_USER_REATTACH_INTERVAL 500000000L
+
 
 /* Name of environment variable to change the dlt log message buffer size */
 #define DLT_USER_ENV_LOG_MSG_BUF_LEN "DLT_LOG_MSG_BUF_LEN"


### PR DESCRIPTION
By checking amount of unsent data in send buffer,
dlt-control will wait until send buffer is empty before exiting.
Thus, dlt-control ensure control message reaches to dlt-daemon.