### PR TITLE
Made writev reliable for fixing data corruption

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -448,7 +448,8 @@ DltReturnValue dlt_init_file(const char *name)
     }
 
     dlt_user.dlt_is_file = 1;
-
+    dlt_is_file_check = dlt_user.dlt_is_file;
+    
     /* open DLT output file */
     dlt_user.dlt_log_handle = open(name, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH); /* mode: wb */
 

--- a/src/shared/dlt_user_shared.h
+++ b/src/shared/dlt_user_shared.h
@@ -75,6 +75,9 @@
 
 #include <sys/types.h>
 
+// Global variable to check the dlt logging is to a file or to FIFO
+int dlt_is_file_check;
+
 /**
  * This is the header of each message to be exchanged between application and daemon.
  */


### PR DESCRIPTION
On random scenario's  "writev()" writes only part of the DLT data to Daemon FIFO due to un-availability of space in Daemon FIFO,  and returns PIPE Error which in turn stores the same complete trace in the applications ring buffer. 
Incomplete trace was read by Daemon(from FIFO) and routed the same to DLT Clients which in turn results in Data corruption at DLT Viewer due to non-availability of complete trace as per the DLT Payload headers.  
Hence proposed solution would check for space availability for each trace prior writing the data to Daemon FIFO, during the failure conditions the data to be stored internally in its application ring buffers and ensuring incomplete traces were not written on to Daemon FIFO.