### PR TITLE
Made writev reliable for fixing data corruption

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -448,7 +448,8 @@ DltReturnValue dlt_init_file(const char *name)
     }
 
     dlt_user.dlt_is_file = 1;
-
+    dlt_is_file_check = dlt_user.dlt_is_file;
+    
     /* open DLT output file */
     dlt_user.dlt_log_handle = open(name, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH); /* mode: wb */
 


### PR DESCRIPTION
Initialized dlt_is_file_check variable which is being used at writev reliable function.