### PR TITLE
Fix a potential memory leak in file transfer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Eckhard Diezel <external.Eckhard.Diezel@de.bosch.com>
 Mohammed AL Dardoun
 Lassi Marttala
 Simon Brandner
+Copyright (c) 2019 MBition GmbH, Andreas Seidl <andreas.seidl@daimler.com>

--- a/src/system/dlt-system-filetransfer.c
+++ b/src/system/dlt-system-filetransfer.c
@@ -274,7 +274,11 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
 
     char *src_copy = strndup(src, PATH_MAX);
     MALLOC_ASSERT(src_copy);
-    char* fdir = dirname(src_copy);/*dirname overwrites its argument anyway, depending on argument the returned address might change */
+
+    /*dirname overwrites its argument anyway, */
+    /*but depending on argument returned address might change */
+    char *fdir = dirname(src_copy);
+
     char *dst_tosend;/*file which is going to be sent */
 
     char *rn = unique_name(src);/*new unique filename based on inode */

--- a/src/system/dlt-system-filetransfer.c
+++ b/src/system/dlt-system-filetransfer.c
@@ -272,9 +272,9 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
         return -1;
     }
 
-    char *fdir = strndup(src, PATH_MAX);
-    MALLOC_ASSERT(fdir);
-    fdir = dirname(fdir);/*dirname overwrites its argument anyway */
+    char *src_copy = strndup(src, PATH_MAX);
+    MALLOC_ASSERT(src_copy);
+    char* fdir = dirname(src_copy);/*dirname overwrites its argument anyway, depending on argument the returned address might change */
     char *dst_tosend;/*file which is going to be sent */
 
     char *rn = unique_name(src);/*new unique filename based on inode */
@@ -308,7 +308,7 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
                     DLT_STRING(dst_tocompress));
             free(rn);
             free(dst_tocompress);
-            free(fdir);
+            free(src_copy);
             return -1;
         }
 
@@ -321,7 +321,7 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
             free(rn);
             free(dst_tosend);
             free(dst_tocompress);
-            free(fdir);
+            free(src_copy);
             return -1;
         }
 
@@ -349,7 +349,7 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
                     DLT_STRING(dst_tosend));
             free(rn);
             free(dst_tosend);
-            free(fdir);
+            free(src_copy);
             return -1;
         }
     }
@@ -362,7 +362,7 @@ int send_one(char *src, FiletransferOptions const *opts, int which)
 
     free(rn);
     free(dst_tosend);
-    free(fdir);
+    free(src_copy);
 
     return 0;
 }


### PR DESCRIPTION
This potential memory leak in dlt-system-filetransfer.c can happen if only a filename
is passed to dirname(). In the current implementation of dlt-daemon, this issue cannot happen.
But in case of refactoring or different usage there is a chance that it can be triggered.
See: https://linux.die.net/man/3/dirname

The program was tested solely for our own use cases, which might differ from yours.

Andreas Seidl <andreas.seidl@daimler.com>, Mercedes-Benz AG on behalf of MBition GmbH
https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md
Licensed under MPL-2.0