### PR TITLE
Fix offline trace files feature

### DIFF
--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -181,6 +181,7 @@ typedef DltDaemonTimingPacketThreadData DltDaemonECUVersionThreadData;
 void dlt_daemon_local_cleanup(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 int dlt_daemon_local_init_p1(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 int dlt_daemon_local_init_p2(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
+int dlt_daemon_local_init_p3(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 int dlt_daemon_local_connection_init(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 int dlt_daemon_local_ecu_version_init(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 


### PR DESCRIPTION
The feature OfflineTrace was working before commit ac44c47265528ddd29afbb9a72bcf095a877ecd,
but with this commit `dlt_daemon_configuration_load()` was moved from within `dlt_daemon_init()` to new `dlt_daemon_load_runtime_configuration()`.
It is called  later in` dlt_daemon_init()` in line dlt-daemon.c:788, which is too late to for reaching `dlt_offline_trace_init()` called by `dlt_daemon_local_init_p2()` called in line dlt-daemon.c:713.

The following configuration was used for verifying the issue and proposed fix

_Configure dlt-runtime.cfg_:
	LoggingMode=3

_Configure dlt.conf_:
	OfflineTraceDirectory = /tmp/dltlogs
	OfflineTraceFileSize = 100
	OfflineTraceMaxSize = 1000
	OfflineTraceFileNameTimestampBased = 0

The program was tested solely for our own use cases, which might differ from yours.

Andreas Seidl andreas.seidl@daimler.com, Mercedes-Benz AG on behalf of MBition GmbH
https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md
Licensed under MPL-2.0