### PR TITLE
Unit test fix

### DIFF
--- a/tests/gtest_dlt_daemon_gateway.cpp
+++ b/tests/gtest_dlt_daemon_gateway.cpp
@@ -337,6 +337,8 @@ TEST(t_dlt_gateway_check_timeout, nullpointer)
 /* Begin Method: dlt_gateway::t_dlt_gateway_establish_connections*/
 TEST(t_dlt_gateway_establish_connections, normal)
 {
+    char ip[] = "127.0.0.1";
+    int port = 3491;
     DltDaemonLocal daemon_local;
     DltGateway *gateway = &daemon_local.pGateway;
     DltGatewayConnection connections;
@@ -344,6 +346,10 @@ TEST(t_dlt_gateway_establish_connections, normal)
     gateway->connections = &connections;
     gateway->connections->status = DLT_GATEWAY_INITIALIZED;
     gateway->connections->trigger = DLT_GATEWAY_ON_STARTUP;
+    gateway->connections->client.mode = DLT_CLIENT_MODE_TCP;
+    gateway->connections->client.servIP = ip;
+    gateway->connections->client.port = port;
+
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_gateway_establish_connections(gateway, &daemon_local, 0));
 }
@@ -536,6 +542,8 @@ TEST(t_dlt_gateway_process_passive_node_messages, nullpointer)
 TEST(t_dlt_gateway_process_gateway_timer, normal)
 {
     char ECUVersionString[] = "12.34";
+    char ip[] = "127.0.0.1";
+    int port = 3491;
     DltDaemon daemon;
     DltDaemonLocal daemon_local;
     DltReceiver receiver;
@@ -546,6 +554,10 @@ TEST(t_dlt_gateway_process_gateway_timer, normal)
     DltLogStorage storage_handle;
     daemon_local.pGateway.connections->status = DLT_GATEWAY_INITIALIZED;
     daemon_local.pGateway.connections->trigger = DLT_GATEWAY_ON_STARTUP;
+    daemon_local.pGateway.connections->client.mode = DLT_CLIENT_MODE_TCP;
+    daemon_local.pGateway.connections->client.servIP = ip;
+    daemon_local.pGateway.connections->client.port = port;
+
 
     daemon_local.pEvent.connections = &connections1;
     daemon_local.pEvent.connections->receiver = &receiver;

--- a/tests/gtest_dlt_daemon_offline_log.cpp
+++ b/tests/gtest_dlt_daemon_offline_log.cpp
@@ -1684,6 +1684,7 @@ TEST(t_dlt_logstorage_sync_msg_cache, null)
 
 int connectServer(void)
 {
+#ifdef DLT_USE_UNIX_SOCKET_IPC
     int sockfd, portno;
     struct sockaddr_in serv_addr;
     struct hostent *server;
@@ -1702,6 +1703,17 @@ int connectServer(void)
         close(sockfd);
         return -1;
     }
+#else
+    char filename[1024];
+    int sockfd;
+    snprintf(filename, 1024, "/tmp/dltpipes/dlt%d", getpid());
+    /* Try to delete existing pipe, ignore result of unlink */
+    unlink(filename);
+
+    mkfifo(filename, S_IRUSR | S_IWUSR | S_IWGRP | S_IRGRP);
+    chmod(filename, S_IRUSR | S_IWUSR | S_IWGRP | S_IRGRP);
+    sockfd = open(filename, O_RDWR | O_CLOEXEC);
+#endif
 
     return sockfd;
 }


### PR DESCRIPTION
- Initialize variables in gtest_dlt_daemon_gateway.cpp to avoid unexpected error.
- Support FIFO mode in connectServer() in gtest_dlt_daemon_logstorage.cpp.

Signed-off-by: Bui Nguyen Quoc Thanh <thanh.buinguyenquoc@vn.bosch.com>