### PR TITLE
cmake-improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@
 # @licence make begin@
 # SPDX license identifier: MPL-2.0
 #
-# Copyright (C) 2011-2015, BMW AG
+# Copyright(C) 2011-2015, BMW AG
 #
 # This file is part of GENIVI Project DLT - Diagnostic Log and Trace.
 #
 # This Source Code Form is subject to the terms of the
-# Mozilla Public License (MPL), v. 2.0.
+# Mozilla Public License(MPL), v. 2.0.
 # If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
@@ -15,32 +15,32 @@
 # @licence end@
 #######
 
-cmake_minimum_required( VERSION 2.8.5 )
-project( automotive-dlt )
+cmake_minimum_required(VERSION 2.8.5)
+project(automotive-dlt)
 
-mark_as_advanced( CMAKE_BACKWARDS_COMPATIBILITY)
-set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE )
+mark_as_advanced(CMAKE_BACKWARDS_COMPATIBILITY)
+set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 
-include ( GNUInstallDirs )
+include(GNUInstallDirs)
 # Set version parameters
-set( DLT_MAJOR_VERSION 2)
-set( DLT_MINOR_VERSION 18)
-set( DLT_PATCH_LEVEL 3)
-set( DLT_VERSION ${DLT_MAJOR_VERSION}.${DLT_MINOR_VERSION}.${DLT_PATCH_LEVEL})
-set( DLT_VERSION_STATE STABLE )
-set( DLT_REVISION "")
+set(DLT_MAJOR_VERSION 2)
+set(DLT_MINOR_VERSION 18)
+set(DLT_PATCH_LEVEL 3)
+set(DLT_VERSION ${DLT_MAJOR_VERSION}.${DLT_MINOR_VERSION}.${DLT_PATCH_LEVEL})
+set(DLT_VERSION_STATE STABLE)
+set(DLT_REVISION "")
 
 execute_process(COMMAND git describe --tags WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	OUTPUT_VARIABLE DLT_REVISION
-	ERROR_VARIABLE GIT_ERROR
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-	ERROR_STRIP_TRAILING_WHITESPACE)
-if( DLT_REVISION MATCHES "^$")
-	set( PRINT_REVISION "Git revision unavailable")
-else( DLT_REVISION MATCHES "")
-	string(REPLACE "-" "_" DLT_REVISION ${DLT_REVISION})
-	set( PRINT_REVISION ${DLT_REVISION})
-endif( DLT_REVISION MATCHES "^$")
+    OUTPUT_VARIABLE DLT_REVISION
+    ERROR_VARIABLE GIT_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE)
+if(DLT_REVISION MATCHES "^$")
+    set(PRINT_REVISION "Git revision unavailable")
+else(DLT_REVISION MATCHES "")
+    string(REPLACE "-" "_" DLT_REVISION ${DLT_REVISION})
+    set(PRINT_REVISION ${DLT_REVISION})
+endif()
 
 # set default build type, if not defined by user
 if(NOT CMAKE_BUILD_TYPE)
@@ -48,218 +48,222 @@ if(NOT CMAKE_BUILD_TYPE)
                          "Choose build type: Debug, Release, RelWithDebInfo, MinSizeRel."
                          FORCE)
     message(STATUS "Build type not defined. Using default build type 'RelWithDebInfo'.")
-endif(NOT CMAKE_BUILD_TYPE)
+endif()
 
 # Set of indiviual options
-option(BUILD_SHARED_LIBS      "Set to OFF to build static libraries"                                             ON  )
-option(WITH_SYSTEMD           "Set to ON to create unit files and systemd check on dlt-daemon startup"           OFF )
+option(BUILD_SHARED_LIBS      "Set to OFF to build static libraries"                                             ON)
+option(WITH_SYSTEMD           "Set to ON to create unit files and systemd check on dlt-daemon startup"           OFF)
 option(WITH_SYSTEMD_WATCHDOG  "Set to ON to use the systemd watchdog in dlt-daemon"                              OFF)
 option(WITH_SYSTEMD_JOURNAL   "Set to ON to use the systemd journal in dlt-system"                               OFF)
-option(WITH_DOC               "Set to ON to build documentation target"                                          OFF )
-option(WITH_MAN               "Set to ON to build man pages"                                                     OFF )
-option(WITH_CHECK_CONFIG_FILE "Set to ON to create a configure file of CheckIncludeFiles and CheckFunctionExists " OFF )
-option(WITH_TESTSCRIPTS       "Set to ON to run CMakeLists.txt in testscripts"                                   OFF )
-option(WITH_GPROF             "Set -pg to compile flags"                                                         OFF )
-option(WITH_DLTTEST			  "Set to ON to build with modifications to test User-Daemon communication with corrupt messages" OFF)
-option(WITH_DLT_SHM_ENABLE    "EXPERIMENTAL! Set to ON to use shared memory as IPC. EXPERIMENTAL!"               OFF )
-option(WITH_DLT_ADAPTOR       "Set to ON to build src/adaptor binaries"                                         OFF)
-option(WITH_DLT_CONSOLE       "Set to ON to build src/console binaries"                                         ON)
-option(WITH_DLT_EXAMPLES      "Set to ON to build src/examples binaries"                                        ON)
-option(WITH_DLT_SYSTEM        "Set to ON to build src/system binaries"                                          OFF)
-option(WITH_DLT_DBUS          "Set to ON to build src/dbus binaries"                                            OFF)
-option(WITH_DLT_TESTS         "Set to ON to build src/test binaries"                                            ON)
-option(WITH_DLT_UNIT_TESTS    "Set to ON to build gtest framework and tests/binaries"                          OFF)
+option(WITH_DOC               "Set to ON to build documentation target"                                          OFF)
+option(WITH_MAN               "Set to ON to build man pages"                                                     OFF)
+option(WITH_CHECK_CONFIG_FILE "Set to ON to create a configure file of CheckIncludeFiles and CheckFunctionExists" OFF)
+option(WITH_TESTSCRIPTS       "Set to ON to run CMakeLists.txt in testscripts"                                   OFF)
+option(WITH_GPROF             "Set -pg to compile flags"                                                         OFF)
+option(WITH_DLTTEST           "Set to ON to build with modifications to test User-Daemon communication with corrupt messages" OFF)
+option(WITH_DLT_SHM_ENABLE    "EXPERIMENTAL! Set to ON to use shared memory as IPC. EXPERIMENTAL!"               OFF)
+option(WITH_DLT_ADAPTOR       "Set to ON to build src/adaptor binaries"                                          OFF)
+option(WITH_DLT_CONSOLE       "Set to ON to build src/console binaries"                                          ON)
+option(WITH_DLT_EXAMPLES      "Set to ON to build src/examples binaries"                                         ON)
+option(WITH_DLT_SYSTEM        "Set to ON to build src/system binaries"                                           OFF)
+option(WITH_DLT_DBUS          "Set to ON to build src/dbus binaries"                                             OFF)
+option(WITH_DLT_TESTS         "Set to ON to build src/test binaries"                                             ON)
+option(WITH_DLT_UNIT_TESTS    "Set to ON to build gtest framework and tests/binaries"                            OFF)
 
 set(DLT_IPC "FIFO" CACHE STRING "UNIX_SOCKET,FIFO")
 set(DLT_USER "genivi" CACHE STRING "Set user for process not run as root")
 
-option(WITH_DLT_CXX11_EXT     "Set to ON to build C++11 extensions"                                             OFF)
-option(WITH_DLT_COREDUMPHANDLER     "EXPERIMENTAL! Set to ON to build src/core_dump_handler binaries. EXPERIMENTAL"                   OFF)
+option(WITH_DLT_PKGCONFIG     "Set to ON to generate pkgconfig .pc files"                                        ON)
+option(WITH_DLT_CXX11_EXT     "Set to ON to build C++11 extensions"                                              OFF)
+option(WITH_DLT_COREDUMPHANDLER "EXPERIMENTAL! Set to ON to build src/core_dump_handler binaries. EXPERIMENTAL"  OFF)
 option(WITH_DLT_LOGSTORAGE_CTRL_UDEV "PROTOTYPE! Set to ON to build logstorage control application with udev support" OFF)
-option(WITH_DLT_LOGSTORAGE_CTRL_PROP "PROTOTYPE! Set to ON to build logstorage control application with proprietary support" OFF)
-option(WITH_DLT_USE_IPv6       "Set to ON for IPv6 support"                                                     ON)
-option(WITH_DLT_KPI        	  "Set to ON to build src/kpi binaries"                                             OFF)
-option(WITH_DLT_FATAL_LOG_TRAP "Set to ON to enable DLT_LOG_FATAL trap (trigger segv inside dlt-user library)"  OFF)
+option(WITH_DLT_USE_IPv6      "Set to ON for IPv6 support"                                                       ON)
+option(WITH_DLT_KPI           "Set to ON to build src/kpi binaries"                                              OFF)
+option(WITH_DLT_FATAL_LOG_TRAP "Set to ON to enable DLT_LOG_FATAL trap(trigger segv inside dlt-user library)"    OFF)
 
 # RPM settings
-set( GENIVI_RPM_RELEASE "1")#${DLT_REVISION}")
-set( LICENSE "Mozilla Public License Version 2.0" )
+set(GENIVI_RPM_RELEASE "1")  # ${DLT_REVISION}")
+set(LICENSE "Mozilla Public License Version 2.0")
 
 # Build, project and include settings
 find_package(Threads REQUIRED)
 if(WITH_DLT_SYSTEM)
-  set(ZLIB_LIBRARY "-lz")
-  find_package(ZLIB REQUIRED)
-else(WITH_DLT_SYSTEM)
-  set(ZLIB_LIBRARY "")
-endif(WITH_DLT_SYSTEM)
+    set(ZLIB_LIBRARY "-lz")
+    find_package(ZLIB REQUIRED)
+else()
+    set(ZLIB_LIBRARY "")
+endif()
 
-find_package(PkgConfig)
 if(WITH_DLT_DBUS)
-  pkg_check_modules(DBUS REQUIRED dbus-1)
-endif(WITH_DLT_DBUS)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(DBUS REQUIRED dbus-1)
+endif()
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/
-    ${CMAKE_SOURCE_DIR}/include/dlt
-    ${CMAKE_SOURCE_DIR}/src/shared/
-    ${CMAKE_SOURCE_DIR}/src/core_dump_handler/
-    ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/
-    ${CMAKE_SOURCE_DIR}/src/lib/
-    ${CMAKE_SOURCE_DIR}/src/daemon/
-    ${CMAKE_SOURCE_DIR}/src/console/
-    ${CMAKE_SOURCE_DIR}/src/gateway/
-    ${CMAKE_SOURCE_DIR}/systemd/3rdparty/
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/include/dlt
+    ${PROJECT_BINARY_DIR}/include/dlt
+    ${PROJECT_SOURCE_DIR}/src/shared
+    ${PROJECT_SOURCE_DIR}/src/core_dump_handler
+    ${PROJECT_SOURCE_DIR}/src/offlinelogstorage
+    ${PROJECT_SOURCE_DIR}/src/lib
+    ${PROJECT_SOURCE_DIR}/src/daemon
+    ${PROJECT_SOURCE_DIR}/src/console
+    ${PROJECT_SOURCE_DIR}/src/gateway
+    ${PROJECT_SOURCE_DIR}/systemd/3rdparty
 )
 
-add_definitions( -D_GNU_SOURCE )
+add_definitions(-D_GNU_SOURCE)
 
-IF(${DLT_IPC} STREQUAL "UNIX_SOCKET")
-    add_definitions( -DDLT_USE_UNIX_SOCKET_IPC )
-ENDIF(${DLT_IPC} STREQUAL "UNIX_SOCKET")
+if(DLT_IPC STREQUAL "UNIX_SOCKET")
+    add_definitions(-DDLT_USE_UNIX_SOCKET_IPC)
+endif()
 
 if(NOT DLT_USER_IPC_PATH)
     set(DLT_USER_IPC_PATH "/tmp")
 endif()
-add_definitions( -DDLT_USER_IPC_PATH="${DLT_USER_IPC_PATH}" )
+add_definitions(-DDLT_USER_IPC_PATH="${DLT_USER_IPC_PATH}")
 
 if(WITH_DLTTEST)
-	add_definitions( -DDLT_TEST_ENABLE)
-endif(WITH_DLTTEST)
+    add_definitions(-DDLT_TEST_ENABLE)
+endif()
 
-if (WITH_DLT_UNIT_TESTS)
+if(WITH_DLT_UNIT_TESTS)
     add_definitions(-DDLT_UNIT_TESTS)
-endif(WITH_DLT_UNIT_TESTS)
+endif()
 
 if(WITH_DLT_SHM_ENABLE)
-    add_definitions( -DDLT_SHM_ENABLE)
-endif(WITH_DLT_SHM_ENABLE)
+    add_definitions(-DDLT_SHM_ENABLE)
+endif()
 
 if(WITH_DLT_USE_IPv6)
-    add_definitions( -DDLT_USE_IPv6)
-endif(WITH_DLT_USE_IPv6)
+    add_definitions(-DDLT_USE_IPv6)
+endif()
+
 
 if(WITH_GPROF)
-  SET(CMAKE_C_FLAGS "-pg")
-endif(WITH_GPROF)
+    add_compile_options(-pg)
+endif()
 
-SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -std=gnu99")
+add_compile_options(
+    $<$<COMPILE_LANGUAGE:C>:-std=gnu99>
+    $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>
+    -Wall
+    -Wextra
+    # -pedantic
+    -Wno-variadic-macros
+    -Wno-strict-aliasing
+    )
 
-add_definitions( "-Wall" )
-add_definitions( "-Wextra" )
-#add_definitions( "-pedantic" )
-add_definitions( "-Wno-variadic-macros" )
-add_definitions( "-Wno-strict-aliasing" )
+if(WITH_DOC STREQUAL "OFF")
+    set(PACKAGE_DOC "#")
+else()
+    set(PACKAGE_DOC "")
+endif()
 
-IF(${WITH_DOC} STREQUAL "OFF")
-	SET(PACKAGE_DOC "#")
-ELSE (${WITH_DOC} STREQUAL "OFF")
-	SET(PACKAGE_DOC "")
-ENDIF(${WITH_DOC} STREQUAL "OFF")
+if(WITH_DLT_PKGCONFIG)
+    configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.spec.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.spec)
+    configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)
+    install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT devel)
+endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.spec.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.spec)
-configure_file(${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT devel)
-
-if(${WITH_DLT_CXX11_EXT})
-    configure_file(${CMAKE_SOURCE_DIR}/${PROJECT_NAME}-c++.pc.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-c++.pc @ONLY)
+if(WITH_DLT_CXX11_EXT AND WITH_DLT_PKGCONFIG)
+    configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}-c++.pc.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-c++.pc @ONLY)
     install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-c++.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT devel)
 endif()
 
-IF(${CMAKE_INSTALL_PREFIX} STREQUAL "/usr")
-	set(CONFIGURATION_FILES_DIR "/etc")
-ELSE()
-	set(CONFIGURATION_FILES_DIR "${CMAKE_INSTALL_PREFIX}/etc")
-ENDIF()
+if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
+    set(CONFIGURATION_FILES_DIR "/etc")
+else()
+    set(CONFIGURATION_FILES_DIR "${CMAKE_INSTALL_PREFIX}/etc")
+endif()
 
 add_definitions(-DCONFIGURATION_FILES_DIR="${CONFIGURATION_FILES_DIR}")
 
-add_subdirectory( cmake )
+add_subdirectory(cmake)
 
 if(WITH_SYSTEMD OR WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD_JOURNAL)
+    find_package(PkgConfig REQUIRED)
     execute_process(COMMAND pkg-config --modversion systemd OUTPUT_VARIABLE SYSTEMD_VERSION)
     string(REPLACE "\n" "" SYSTEMD_VERSION ${SYSTEMD_VERSION})
 
     if(WITH_SYSTEMD)
-        add_definitions( -DDLT_SYSTEMD_ENABLE)
-    endif(WITH_SYSTEMD)
+        add_definitions(-DDLT_SYSTEMD_ENABLE)
+    endif()
 
     if(WITH_SYSTEMD_WATCHDOG)
-        add_definitions( -DDLT_SYSTEMD_WATCHDOG_ENABLE)
-    endif(WITH_SYSTEMD_WATCHDOG)
+        add_definitions(-DDLT_SYSTEMD_WATCHDOG_ENABLE)
+    endif()
 
     if(WITH_SYSTEMD_JOURNAL)
-        add_definitions( -DDLT_SYSTEMD_JOURNAL_ENABLE)
-    endif(WITH_SYSTEMD_JOURNAL)
+        add_definitions(-DDLT_SYSTEMD_JOURNAL_ENABLE)
+    endif()
 
-    set( systemd_SRCS ${CMAKE_SOURCE_DIR}/systemd/3rdparty/sd-daemon.c)
+    set(systemd_SRCS ${PROJECT_SOURCE_DIR}/systemd/3rdparty/sd-daemon.c)
 
     set(SYSTEMD_UNITDIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/system" CACHE PATH
         "Set directory to install systemd unit files")
 
-    add_subdirectory( systemd )
-endif(WITH_SYSTEMD OR WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD_JOURNAL)
+    add_subdirectory(systemd)
+endif()
 
 if(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
-	add_definitions( -DDLT_LOGSTORAGE_CTRL_UDEV_ENABLE)
-endif(WITH_DLT_LOGSTORAGE_CTRL_UDEV)
+    add_definitions(-DDLT_LOGSTORAGE_CTRL_UDEV_ENABLE)
+endif()
 
-if(WITH_DLT_LOGSTORAGE_CTRL_PROP)
-	add_definitions( -DHAS_PROPRIETARY_LOGSTORAGE)
-endif(WITH_DLT_LOGSTORAGE_CTRL_PROP)
+if(WITH_DLT_FATAL_LOG_TRAP)
+    add_definitions(-DDLT_FATAL_LOG_RESET_ENABLE)
+endif()
 
-if (WITH_DLT_FATAL_LOG_TRAP)
-    add_definitions( -DDLT_FATAL_LOG_RESET_ENABLE)
-endif(WITH_DLT_FATAL_LOG_TRAP)
-
-add_subdirectory( doc )
-add_subdirectory( src )
-add_subdirectory( include )
-add_subdirectory( testscripts )
-if (WITH_DLT_UNIT_TESTS)
+add_subdirectory(doc)
+add_subdirectory(src)
+add_subdirectory(include/dlt)
+add_subdirectory(testscripts)
+if(WITH_DLT_UNIT_TESTS)
     add_subdirectory( gtest-1.7.0 )
-    add_subdirectory( tests )
-endif(WITH_DLT_UNIT_TESTS)
+    add_subdirectory(tests)
+endif()
 
-message( STATUS )
-message( STATUS "-------------------------------------------------------------------------------" )
-message( STATUS "Build for Version ${DLT_VERSION} build ${DLT_REVISION} version state ${DLT_VERSION_STATE}")
-message( STATUS "WITH_SYSTEMD = ${WITH_SYSTEMD}" )
-message( STATUS "WITH_SYSTEMD_WATCHDOG = ${WITH_SYSTEMD_WATCHDOG}" )
-message( STATUS "WITH_SYSTEMD_JOURNAL = ${WITH_SYSTEMD_JOURNAL}" )
-message( STATUS "WITH_DOC = ${WITH_DOC}" )
+message(STATUS)
+message(STATUS "-------------------------------------------------------------------------------")
+message(STATUS "Build for Version ${DLT_VERSION} build ${DLT_REVISION} version state ${DLT_VERSION_STATE}")
+message(STATUS "WITH_SYSTEMD = ${WITH_SYSTEMD}")
+message(STATUS "WITH_SYSTEMD_WATCHDOG = ${WITH_SYSTEMD_WATCHDOG}")
+message(STATUS "WITH_SYSTEMD_JOURNAL = ${WITH_SYSTEMD_JOURNAL}")
+message(STATUS "WITH_DOC = ${WITH_DOC}")
 
-message( STATUS "WITH_MAN = ${WITH_MAN}" )
-message( STATUS "WITH_DLT_ADAPTOR = ${WITH_DLT_ADAPTOR}")
-message( STATUS "WITH_DLT_CONSOLE = ${WITH_DLT_CONSOLE}")
-message( STATUS "WITH_DLT_EXAMPLES = ${WITH_DLT_EXAMPLES}")
-message( STATUS "WITH_DLT_SYSTEM = ${WITH_DLT_SYSTEM}")
-message( STATUS "WITH_DLT_DBUS = ${WITH_DLT_DBUS}")
-message( STATUS "WITH_DLT_TESTS = ${WITH_DLT_TESTS}")
-message( STATUS "WITH_DLT_UNIT_TESTS = ${WITH_DLT_UNIT_TESTS}" )
-message( STATUS "WITH_DLT_SHM_ENABLE = ${WITH_DLT_SHM_ENABLE}" )
-message( STATUS "WITH_DLTTEST = ${WITH_DLTTEST}" )
-message( STATUS "WITH_DLT_CXX11_EXT = ${WITH_DLT_CXX11_EXT}" )
-message( STATUS "WITH_DLT_COREDUMPHANDLER = ${WITH_DLT_COREDUMPHANDLER}" )
-message( STATUS "WITH_DLT_KPI = ${WITH_DLT_KPI}" )
-message( STATUS "WITH_CHECK_CONFIG_FILE = ${WITH_CHECK_CONFIG_FILE}" )
-message( STATUS "WITH_TESTSCRIPTS = ${WITH_TESTSCRIPTS}" )
-message( STATUS "WITH_GPROF = ${WITH_GPROF}" )
-message( STATUS "WITH_DLT_USE_IPv6 = ${WITH_DLT_USE_IPv6}" )
-message( STATUS "DLT_USER = ${DLT_USER}" )
-message( STATUS "BUILD_SHARED_LIBS = ${BUILD_SHARED_LIBS}" )
-message( STATUS "TARGET_CPU_NAME = ${TARGET_CPU_NAME}" )
+message(STATUS "WITH_MAN = ${WITH_MAN}")
+message(STATUS "WITH_DLT_ADAPTOR = ${WITH_DLT_ADAPTOR}")
+message(STATUS "WITH_DLT_CONSOLE = ${WITH_DLT_CONSOLE}")
+message(STATUS "WITH_DLT_EXAMPLES = ${WITH_DLT_EXAMPLES}")
+message(STATUS "WITH_DLT_SYSTEM = ${WITH_DLT_SYSTEM}")
+message(STATUS "WITH_DLT_DBUS = ${WITH_DLT_DBUS}")
+message(STATUS "WITH_DLT_TESTS = ${WITH_DLT_TESTS}")
+message(STATUS "WITH_DLT_UNIT_TESTS = ${WITH_DLT_UNIT_TESTS}")
+message(STATUS "WITH_DLT_SHM_ENABLE = ${WITH_DLT_SHM_ENABLE}")
+message(STATUS "WITH_DLTTEST = ${WITH_DLTTEST}")
+message(STATUS "WITH_DLT_PKGCONFIG = ${WITH_DLT_PKGCONFIG}")
+message(STATUS "WITH_DLT_CXX11_EXT = ${WITH_DLT_CXX11_EXT}")
+message(STATUS "WITH_DLT_COREDUMPHANDLER = ${WITH_DLT_COREDUMPHANDLER}")
+message(STATUS "WITH_DLT_KPI = ${WITH_DLT_KPI}")
+message(STATUS "WITH_DLT_FATAL_LOG_TRAP = ${WITH_DLT_FATAL_LOG_TRAP}")
+message(STATUS "WITH_CHECK_CONFIG_FILE = ${WITH_CHECK_CONFIG_FILE}")
+message(STATUS "WITH_TESTSCRIPTS = ${WITH_TESTSCRIPTS}")
+message(STATUS "WITH_GPROF = ${WITH_GPROF}")
+message(STATUS "WITH_DLT_USE_IPv6 = ${WITH_DLT_USE_IPv6}")
+message(STATUS "DLT_USER = ${DLT_USER}")
+message(STATUS "BUILD_SHARED_LIBS = ${BUILD_SHARED_LIBS}")
+message(STATUS "TARGET_CPU_NAME = ${TARGET_CPU_NAME}")
 if(WITH_SYSTEMD OR WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD_JOURNAL)
-    message( STATUS "SYSTEMD_VERSION = ${SYSTEMD_VERSION}")
-    message( STATUS "SYSTEMD_UNITDIR = ${SYSTEMD_UNITDIR}" )
-endif(WITH_SYSTEMD OR WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD_JOURNAL)
-message( STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}" )
-message( STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}" )
-message( STATUS "CMAKE_HOST_SYSTEM_PROCESSOR = ${CMAKE_HOST_SYSTEM_PROCESSOR}" )
-message( STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}" )
-message( STATUS "WITH_DLT_LOGSTORAGE_CTRL_UDEV = ${WITH_DLT_LOGSTORAGE_CTRL_UDEV}" )
-message( STATUS "WITH_DLT_LOGSTORAGE_CTRL_PROP = ${WITH_DLT_LOGSTORAGE_CTRL_PROP}" )
-message( STATUS "DLT_IPC = ${DLT_IPC} (Path: ${DLT_USER_IPC_PATH})" )
-message( STATUS "Change a value with: cmake -D<Variable>=<Value>" )
-message( STATUS "-------------------------------------------------------------------------------" )
-message( STATUS )
+    message(STATUS "SYSTEMD_VERSION = ${SYSTEMD_VERSION}")
+    message(STATUS "SYSTEMD_UNITDIR = ${SYSTEMD_UNITDIR}")
+endif()
+message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMAKE_HOST_SYSTEM_PROCESSOR = ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+message(STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "WITH_DLT_LOGSTORAGE_CTRL_UDEV = ${WITH_DLT_LOGSTORAGE_CTRL_UDEV}")
+message(STATUS "DLT_IPC = ${DLT_IPC}(Path: ${DLT_USER_IPC_PATH})")
+message(STATUS "Change a value with: cmake -D<Variable>=<Value>")
+message(STATUS "-------------------------------------------------------------------------------")
+message(STATUS)

--- a/include/dlt/CMakeLists.txt
+++ b/include/dlt/CMakeLists.txt
@@ -15,13 +15,16 @@
 # @licence end@
 #######
 
-install(FILES dlt.h dlt_user.h dlt_user_macros.h dlt_client.h dlt_protocol.h dlt_common.h dlt_types.h dlt_version.h dlt_shm.h dlt_offline_trace.h dlt_filetransfer.h dlt_common_api.h
+install(FILES dlt.h dlt_user.h dlt_user_macros.h dlt_client.h dlt_protocol.h
+              dlt_common.h dlt_types.h dlt_shm.h dlt_offline_trace.h
+              dlt_filetransfer.h dlt_common_api.h
+              ${PROJECT_BINARY_DIR}/include/dlt/dlt_version.h
         DESTINATION include/dlt
         COMPONENT devel)
 
-
-if(${WITH_DLT_CXX11_EXT})
-  install(FILES dlt_cpp_extension.hpp
-          DESTINATION include/dlt
-          COMPONENT devel)
+if(WITH_DLT_CXX11_EXT)
+    install(FILES dlt_cpp_extension.hpp
+            DESTINATION include/dlt
+            COMPONENT devel)
 endif()
+

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -15,33 +15,27 @@
 # @licence end@
 #######
 
-set(dlt_sortbytimestamp_SRCS dlt-sortbytimestamp.c)
-add_executable(dlt-sortbytimestamp ${dlt_sortbytimestamp_SRCS} ${dlt_most_SRCS})
-target_link_libraries(dlt-sortbytimestamp dlt ${EXPAT_LIBRARIES})
-set_target_properties(dlt-sortbytimestamp PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_convert_SRCS dlt-convert.c)
-add_executable(dlt-convert ${dlt_convert_SRCS} ${dlt_most_SRCS})
-target_link_libraries(dlt-convert dlt ${EXPAT_LIBRARIES})
-set_target_properties(dlt-convert PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_receive_SRCS dlt-receive.c)
-add_executable(dlt-receive ${dlt_receive_SRCS} ${dlt_most_SRCS})
-target_link_libraries(dlt-receive dlt ${EXPAT_LIBRARIES})
-set_target_properties(dlt-receive PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_control_SRCS dlt-control.c dlt-control-common.c)
-add_executable(dlt-control ${dlt_control_SRCS} ${dlt_most_SRCS})
-target_link_libraries(dlt-control dlt ${EXPAT_LIBRARIES})
-set_target_properties(dlt-control PROPERTIES LINKER_LANGUAGE C)
-
 set(dlt_control_common_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/dlt-control-common.c)
-add_subdirectory( logstorage )
+add_subdirectory(logstorage)
 
-set(dlt_passive_node_ctrl_SRCS dlt-passive-node-ctrl.c dlt-control-common.c)
-add_executable(dlt-passive-node-ctrl ${dlt_passive_node_ctrl_SRCS} ${dlt_most_SRCS})
-target_link_libraries(dlt-passive-node-ctrl dlt ${EXPAT_LIBRARIES})
+set(dlt-sortbytimestamp_SRCS dlt-sortbytimestamp.c)
+set(dlt-convert_SRCS dlt-convert.c)
+set(dlt-receive_SRCS dlt-receive.c)
+set(dlt-control_SRCS dlt-control.c ${dlt_control_common_SRCS})
+set(dlt-passive-node-ctrl_SRCS dlt-passive-node-ctrl.c ${dlt_control_common_SRCS})
 
-install(TARGETS dlt-sortbytimestamp dlt-convert dlt-receive dlt-control dlt-passive-node-ctrl
-	RUNTIME DESTINATION bin
-	COMPONENT base)
+foreach(target
+        dlt-sortbytimestamp
+        dlt-convert
+        dlt-receive
+        dlt-control
+        dlt-passive-node-ctrl
+        )
+    add_executable(${target} ${${target}_SRCS})
+    target_link_libraries(${target} dlt)
+    set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)
+
+    install(TARGETS ${target}
+            RUNTIME DESTINATION bin
+            COMPONENT base)
+endforeach()

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -17,14 +17,37 @@
 
 
 if(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
-    message( STATUS "Added ${systemd_SRCS} to dlt-daemon")
-endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
+    message(STATUS "Added ${systemd_SRCS} to dlt-daemon")
+endif()
 
-set(dlt_daemon_SRCS dlt-daemon.c dlt_daemon_common.c dlt_daemon_connection.c dlt_daemon_event_handler.c ${CMAKE_SOURCE_DIR}/src/gateway/dlt_gateway.c dlt_daemon_socket.c dlt_daemon_unix_socket.c dlt_daemon_serial.c dlt_daemon_client.c dlt_daemon_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_offline_trace.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c ${CMAKE_SOURCE_DIR}/src/lib/dlt_client.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_config_file_parser.c ${CMAKE_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+set(dlt_daemon_SRCS
+    dlt-daemon.c
+    dlt_daemon_client.c
+    dlt_daemon_common.c
+    dlt_daemon_connection.c
+    dlt_daemon_event_handler.c
+    dlt_daemon_offline_logstorage.c
+    dlt_daemon_serial.c
+    dlt_daemon_socket.c
+    dlt_daemon_unix_socket.c
+    ${PROJECT_SOURCE_DIR}/src/gateway/dlt_gateway.c
+    ${PROJECT_SOURCE_DIR}/src/lib/dlt_client.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_common.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_config_file_parser.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_offline_trace.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_protocol.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_user_shared.c
+    ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c
+    ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+    )
 
 if(WITH_DLT_SHM_ENABLE)
-    set(dlt_daemon_SRCS ${dlt_daemon_SRCS} ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c)
+    set(dlt_daemon_SRCS
+        ${dlt_daemon_SRCS}
+        ${PROJECT_SOURCE_DIR}/src/shared/dlt_shm.c)
 endif()
+
+add_executable(dlt-daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(RT_LIBRARY rt)
@@ -34,19 +57,26 @@ else()
     set(SOCKET_LIBRARY socket)
 endif()
 
-add_executable(dlt-daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
 target_link_libraries(dlt-daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS dlt-daemon
-	RUNTIME DESTINATION bin
-	PERMISSIONS 	OWNER_EXECUTE OWNER_WRITE OWNER_READ
-			GROUP_EXECUTE GROUP_READ
-			WORLD_EXECUTE WORLD_READ
-	COMPONENT base)
+        RUNTIME DESTINATION bin
+        PERMISSIONS
+            OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            GROUP_EXECUTE GROUP_READ
+            WORLD_EXECUTE WORLD_READ
+        COMPONENT base)
 
 if (WITH_DLT_UNIT_TESTS)
-    add_library(dlt_daemon ${dlt_daemon_SRCS})
+    set(library_SRCS ${dlt_daemon_SRCS})
+
+    if (WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
+        set(library_SRCS ${library_SRCS} ${systemd_SRCS})
+    endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
+
+    add_library(dlt_daemon ${library_SRCS})
     target_link_libraries(dlt_daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+
     install(TARGETS dlt_daemon
             RUNTIME DESTINATION bin
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -15,11 +15,19 @@
 # @licence end@
 #######
 
-set(dlt_LIB_SRCS dlt_user dlt_client dlt_filetransfer dlt_env_ll ${CMAKE_SOURCE_DIR}/src/shared/dlt_common.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_user_shared.c ${CMAKE_SOURCE_DIR}/src/shared/dlt_protocol.c)
+set(dlt_LIB_SRCS
+    dlt_user.c
+    dlt_client.c
+    dlt_filetransfer.c
+    dlt_env_ll.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_common.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_protocol.c
+    ${PROJECT_SOURCE_DIR}/src/shared/dlt_user_shared.c
+    )
 
 if(WITH_DLT_SHM_ENABLE)
-    set(dlt_LIB_SRCS ${dlt_LIB_SRCS} ${CMAKE_SOURCE_DIR}/src/shared/dlt_shm.c)
-endif(WITH_DLT_SHM_ENABLE)
+    set(dlt_LIB_SRCS ${dlt_LIB_SRCS} ${PROJECT_SOURCE_DIR}/src/shared/dlt_shm.c)
+endif()
 
 add_library(dlt ${dlt_LIB_SRCS})
 
@@ -31,14 +39,18 @@ else()
     set(SOCKET_LIBRARY socket)
 endif()
 
-target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+if(HAVE_FUNC_PTHREAD_SETNAME_NP)
+    add_definitions(-DDLT_USE_PTHREAD_SETNAME_NP)
+    message(STATUS "Using pthread_setname_np API to set thread name")
+else()
+    message(STATUS "pthread_setname_np API not available on this platform")
+endif()
 
+target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(dlt PROPERTIES VERSION ${DLT_VERSION} SOVERSION ${DLT_MAJOR_VERSION})
 
 install(TARGETS dlt
-	RUNTIME DESTINATION bin
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
-	COMPONENT base)
-
-
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
+        COMPONENT base)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,60 +15,36 @@
 # @licence end@
 #######
 
-set(dlt_test_multi_process_SRCS dlt-test-multi-process.c)
-add_executable(dlt-test-multi-process ${dlt_test_multi_process_SRCS})
-target_link_libraries(dlt-test-multi-process dlt)
-set_target_properties(dlt-test-multi-process PROPERTIES LINKER_LANGUAGE C)
+set(dlt-test-multi-process_SRCS dlt-test-multi-process.c)
+set(dlt-test-multi-process-client_SRCS dlt-test-multi-process-client.c)
+set(dlt-test-user_SRCS dlt-test-user.c)
+set(dlt-test-client_SRCS dlt-test-client.c)
+set(dlt-test-stress-user_SRCS dlt-test-stress-user.c)
+set(dlt-test-stress-client_SRCS dlt-test-stress-client.c)
+set(dlt-test-stress_SRCS dlt-test-stress.c)
+set(dlt-test-filetransfer_SRCS dlt-test-filetransfer.c)
+set(dlt-test-fork-handler_SRCS dlt-test-fork-handler.c)
+set(dlt-test-init-free_SRCS dlt-test-init-free.c)
 
-set(dlt_test_multi_process_client_SRCS dlt-test-multi-process-client.c)
-add_executable(dlt-test-multi-process-client ${dlt_test_multi_process_client_SRCS})
-target_link_libraries(dlt-test-multi-process-client dlt)
-set_target_properties(dlt-test-multi-process-client PROPERTIES LINKER_LANGUAGE C)
+foreach(target
+        dlt-test-multi-process
+        dlt-test-multi-process-client
+        dlt-test-user
+        dlt-test-client
+        dlt-test-stress-user
+        dlt-test-stress-client
+        dlt-test-stress
+        dlt-test-filetransfer
+        dlt-test-fork-handler
+        dlt-test-init-free
+        )
+    add_executable(${target} ${${target}_SRCS})
+    target_link_libraries(${target} dlt)
+    set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)
+    install(TARGETS ${target}
+            RUNTIME DESTINATION bin
+            COMPONENT base)
+endforeach()
 
-set(dlt_test_user_SRCS dlt-test-user.c)
-add_executable(dlt-test-user ${dlt_test_user_SRCS})
-target_link_libraries(dlt-test-user dlt)
-set_target_properties(dlt-test-user PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_client_SRCS dlt-test-client.c)
-add_executable(dlt-test-client ${dlt_test_client_SRCS})
-target_link_libraries(dlt-test-client dlt)
-set_target_properties(dlt-test-client PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_stress_user_SRCS dlt-test-stress-user.c)
-add_executable(dlt-test-stress-user ${dlt_test_stress_user_SRCS})
-target_link_libraries(dlt-test-stress-user dlt)
-set_target_properties(dlt-test-stress-user PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_stress_client_SRCS dlt-test-stress-client.c)
-add_executable(dlt-test-stress-client ${dlt_test_stress_client_SRCS})
-target_link_libraries(dlt-test-stress-client dlt)
-set_target_properties(dlt-test-stress-client PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_stress_SRCS dlt-test-stress.c)
-add_executable(dlt-test-stress ${dlt_test_stress_SRCS})
-target_link_libraries(dlt-test-stress dlt)
-set_target_properties(dlt-test-stress PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_filetransfer_SRCS dlt-test-filetransfer.c)
-add_executable(dlt-test-filetransfer ${dlt_test_filetransfer_SRCS})
-target_link_libraries(dlt-test-filetransfer dlt)
-set_target_properties(dlt-test-filetransfer PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_fork_handler_SRCS dlt-test-fork-handler.c)
-add_executable(dlt-test-fork-handler ${dlt_test_fork_handler_SRCS})
-target_link_libraries(dlt-test-fork-handler dlt)
-set_target_properties(dlt-test-fork-handler PROPERTIES LINKER_LANGUAGE C)
-
-set(dlt_test_init_free_SRCS dlt-test-init-free.c)
-add_executable(dlt-test-init-free ${dlt_test_init_free_SRCS})
-target_link_libraries(dlt-test-init-free dlt)
-set_target_properties(dlt-test-init-free PROPERTIES LINKER_LANGUAGE C)
-
-install(TARGETS dlt-test-multi-process dlt-test-multi-process-client dlt-test-user dlt-test-client dlt-test-stress-user dlt-test-stress-client dlt-test-stress dlt-test-filetransfer dlt-test-fork-handler dlt-test-init-free
-	RUNTIME DESTINATION bin
-	COMPONENT base)
-
-INSTALL(FILES dlt-test-filetransfer-file dlt-test-filetransfer-image.png
-	DESTINATION share/dlt-filetransfer
-)
+install(FILES dlt-test-filetransfer-file dlt-test-filetransfer-image.png
+        DESTINATION share/dlt-filetransfer)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,15 +1,10 @@
 # Setup testing
 enable_testing()
 
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -isystem ${gtest_SOURCE_DIR}/include")
+#add_compile_options(-g -fsanitize=address)
+add_compile_options(-isystem ${gtest_SOURCE_DIR}/include)
 
-#SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g")
-#SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fsanitize=address")
-
-SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=gnu++0x")
-
-configure_file(${CMAKE_SOURCE_DIR}/tests/testfile.dlt ${PROJECT_BINARY_DIR}/tests COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/tests/testfilter.txt ${PROJECT_BINARY_DIR}/tests COPYONLY)
+configure_file(${PROJECT_SOURCE_DIR}/tests/testfile.dlt ${PROJECT_BINARY_DIR}/tests COPYONLY)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(LIBRARIES gtest gtest_main)
@@ -43,8 +38,7 @@ target_link_libraries(gtest_dlt_daemon_gateway ${DLT_DAEMON_LIBRARIES})
 target_link_libraries(gtest_dlt_daemon_event_handler ${DLT_DAEMON_LIBRARIES})
 target_link_libraries(gtest_dlt_daemon_offline_log ${DLT_DAEMON_LIBRARIES})
 
-if(${WITH_DLT_CXX11_EXT})
+if(WITH_DLT_CXX11_EXT)
   add_executable(dlt-test-cpp-extension dlt-test-cpp-extension.cpp)
-  set_target_properties(dlt-test-cpp-extension PROPERTIES COMPILE_FLAGS "-std=gnu++0x")
   target_link_libraries(dlt-test-cpp-extension ${DLT_LIBRARIES})
 endif()


### PR DESCRIPTION
1. Allow building as a subproject of another
cmake project (CMAKE_* vs PROJECT_* variables)

2. Do not generate header files within source – bad practice, use build
directory for that(e.g. change location where dlt_version.h is being generated)

3. Use add_compile_options() instead of *_C/CXX_FLAGS variables for proper
compile environment definition, also bad practice, also see p.2

4. Add WITH_DLT_PKGCONFIG – add generate pkgconfig .pc files as switchable
option, should probably be part of headers install routine.

Signed-off-by: Radoslaw Kaczorowski <external.radoslaw.kaczorowski@bosch-softtec.com>