### PR TITLE
define DLT_PATH_MAX for max path buffer length

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -350,6 +350,14 @@ enum {
 #   define DLT_RCV_REMOVE      (1 << 1)
 
 /**
+ * Maximal length of path in DLT
+ * DLT limits the path length and does not do anything else to determine
+ * the actual value, because the least that is supported on any system
+ * that DLT runs on is 1024 bytes.
+ */
+#   define DLT_PATH_MAX 1024
+
+/**
  * Maximal length of mounted path
  */
 #   define DLT_MOUNT_PATH_MAX  1024
@@ -413,7 +421,7 @@ extern char dltSerialHeaderChar[DLT_ID_SIZE];
 /**
  * The common base-path of the dlt-daemon-fifo and application-generated fifos
  */
-extern char dltFifoBaseDir[PATH_MAX + 1];
+extern char dltFifoBaseDir[DLT_PATH_MAX];
 
 /**
  * The type of a DLT ID (context id, application id, etc.)

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -130,7 +130,8 @@ int option_handling(DltDaemonLocal *daemon_local, int argc, char *argv[])
 
     /* default values */
     daemon_local->flags.port = DLT_DAEMON_TCP_PORT;
-    strncpy(dltFifoBaseDir, DLT_USER_IPC_PATH, sizeof(DLT_USER_IPC_PATH));
+    strncpy(dltFifoBaseDir, DLT_USER_IPC_PATH, DLT_PATH_MAX);
+    dltFifoBaseDir[DLT_PATH_MAX - 1] = 0;
 
     opterr = 0;
 
@@ -148,7 +149,8 @@ int option_handling(DltDaemonLocal *daemon_local, int argc, char *argv[])
         }
         case 't':
         {
-            strncpy(dltFifoBaseDir, optarg, NAME_MAX);
+            strncpy(dltFifoBaseDir, optarg, DLT_PATH_MAX);
+            dltFifoBaseDir[DLT_PATH_MAX - 1] = 0;
             break;
         }
         case 'p':
@@ -189,9 +191,11 @@ int option_handling(DltDaemonLocal *daemon_local, int argc, char *argv[])
 
 
 #ifndef DLT_USE_UNIX_SOCKET_IPC
-    snprintf(daemon_local->flags.userPipesDir, NAME_MAX + 1, "%s/dltpipes", dltFifoBaseDir);
+    snprintf(daemon_local->flags.userPipesDir, DLT_PATH_MAX,
+             "%s/dltpipes", dltFifoBaseDir);
 #endif
-    snprintf(daemon_local->flags.daemonFifoName, NAME_MAX + 1, "%s/dlt", dltFifoBaseDir);
+    snprintf(daemon_local->flags.daemonFifoName, DLT_PATH_MAX,
+             "%s/dlt", dltFifoBaseDir);
 
     return 0;
 
@@ -220,10 +224,9 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     daemon_local->flags.loggingMode = DLT_LOG_TO_CONSOLE;
     daemon_local->flags.loggingLevel = LOG_INFO;
     snprintf(daemon_local->flags.loggingFilename,
-             sizeof(daemon_local->flags.loggingFilename) - 1,
+             sizeof(daemon_local->flags.loggingFilename),
              "%s/dlt.log",
              dltFifoBaseDir);
-    daemon_local->flags.loggingFilename[sizeof(daemon_local->flags.loggingFilename) - 1] = 0;
     daemon_local->timeoutOnSend = 4;
     daemon_local->RingbufferMinSize = DLT_DAEMON_RINGBUFFER_MIN_SIZE;
     daemon_local->RingbufferMaxSize = DLT_DAEMON_RINGBUFFER_MAX_SIZE;
@@ -1296,9 +1299,9 @@ void dlt_daemon_local_cleanup(DltDaemon *daemon, DltDaemonLocal *daemon_local, i
 
 void dlt_daemon_exit_trigger()
 {
-    char tmp[PATH_MAX + 1] = { 0 };
+    char tmp[DLT_PATH_MAX] = { 0 };
 
-    snprintf(tmp, PATH_MAX, "%s/dlt", dltFifoBaseDir);
+    snprintf(tmp, DLT_PATH_MAX, "%s/dlt", dltFifoBaseDir);
     (void)unlink(tmp);
 
     /* stop event loop */

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -122,9 +122,9 @@ typedef struct
 #ifdef DLT_USE_UNIX_SOCKET_IPC
     char appSockPath[DLT_DAEMON_FLAG_MAX]; /**< Path to User socket */
 #else
-    char userPipesDir[NAME_MAX + 1]; /**< (String: Directory) directory where dltpipes reside (Default: /tmp/dltpipes) */
+    char userPipesDir[DLT_PATH_MAX]; /**< (String: Directory) directory where dltpipes reside (Default: /tmp/dltpipes) */
 #endif
-    char daemonFifoName[NAME_MAX + 1]; /**< (String: Filename) name of local fifo (Default: /tmp/dlt) */
+    char daemonFifoName[DLT_PATH_MAX]; /**< (String: Filename) name of local fifo (Default: /tmp/dlt) */
     unsigned int port;  /**< port number */
     char ctrlSockPath[DLT_DAEMON_FLAG_MAX]; /**< Path to Control socket */
     int gatewayMode; /**< (Boolean) Gateway Mode */

--- a/src/dbus/dlt-dbus-options.c
+++ b/src/dbus/dlt-dbus-options.c
@@ -82,21 +82,21 @@ int read_command_line(DltDBusCliOptions *options, int argc, char *argv[])
         {
             options->BusType = malloc(strlen(optarg) + 1);
             MALLOC_ASSERT(options->BusType);
-            strcpy(options->BusType, optarg);     /* strcpy unritical here, because size matches exactly the size to be copied */
+            strcpy(options->BusType, optarg); /* strcpy uncritical here, because size matches exactly the size to be copied */
             break;
         }
         case 'a':
         {
             options->ApplicationId = malloc(strlen(optarg) + 1);
             MALLOC_ASSERT(options->ApplicationId);
-            strcpy(options->ApplicationId, optarg);     /* strcpy unritical here, because size matches exactly the size to be copied */
+            strcpy(options->ApplicationId, optarg); /* strcpy uncritical here, because size matches exactly the size to be copied */
             break;
         }
         case 'c':
         {
             options->ConfigurationFileName = malloc(strlen(optarg) + 1);
             MALLOC_ASSERT(options->ConfigurationFileName);
-            strcpy(options->ConfigurationFileName, optarg);     /* strcpy unritical here, because size matches exactly the size to be copied */
+            strcpy(options->ConfigurationFileName, optarg); /* strcpy uncritical here, because size matches exactly the size to be copied */
             break;
         }
         case 'h':

--- a/src/dbus/dlt-dbus.h
+++ b/src/dbus/dlt-dbus.h
@@ -31,7 +31,7 @@
 #include "dlt.h"
 #include "dlt_common.h"
 
-#define DEFAULT_CONF_FILE "/etc/dlt-dbus.conf"
+#define DEFAULT_CONF_FILE CONFIGURATION_FILES_DIR "/dlt-dbus.conf"
 
 #define DLT_DBUS_FILTER_MAX 32
 

--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -357,7 +357,7 @@ DLT_STATIC int dlt_logstorage_read_list_of_names(char **names, char *value)
         strncpy((*names + y), tok, len);
 
         if ((num > 1) && (i < num))
-            strncpy((*names + y + len), ",", 1);
+            strncpy((*names + y + len), ",", 2);
 
         y += len + 1;
 
@@ -1554,7 +1554,7 @@ DLT_STATIC int dlt_logstorage_store_filters(DltLogStorage *handle,
  */
 DLT_STATIC int dlt_logstorage_load_config(DltLogStorage *handle)
 {
-    char config_file_name[PATH_MAX + 1] = { '\0' };
+    char config_file_name[PATH_MAX] = {0};
     int ret = 0;
 
     /* Check if handle is NULL or already initialized or already configured  */
@@ -1579,7 +1579,7 @@ DLT_STATIC int dlt_logstorage_load_config(DltLogStorage *handle)
                 "Creating configuration file path string failed\n");
         return -1;
     }
-
+    config_file_name[PATH_MAX - 1] = 0;
     ret = dlt_logstorage_store_filters(handle, config_file_name);
 
     if (ret == 1) {
@@ -1624,6 +1624,7 @@ int dlt_logstorage_device_connected(DltLogStorage *handle, char *mount_point)
     }
 
     strncpy(handle->device_mount_point, mount_point, DLT_MOUNT_PATH_MAX);
+    handle->device_mount_point[DLT_MOUNT_PATH_MAX] = 0;
     handle->connection_type = DLT_OFFLINE_LOGSTORAGE_DEVICE_CONNECTED;
     handle->config_status = 0;
     handle->write_errors = 0;
@@ -1653,7 +1654,7 @@ int dlt_logstorage_device_disconnected(DltLogStorage *handle, int reason)
         dlt_logstorage_free(handle, reason);
 
     /* Reset all device status */
-    memset(handle->device_mount_point, '\0', sizeof(char) * DLT_MOUNT_PATH_MAX);
+    memset(handle->device_mount_point, 0, sizeof(char) * (DLT_MOUNT_PATH_MAX + 1));
     handle->connection_type = DLT_OFFLINE_LOGSTORAGE_DEVICE_DISCONNECTED;
     handle->config_status = 0;
     handle->write_errors = 0;

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -67,7 +67,7 @@
 
 const char dltSerialHeader[DLT_ID_SIZE] = { 'D', 'L', 'S', 1 };
 char dltSerialHeaderChar[DLT_ID_SIZE] = { 'D', 'L', 'S', 1 };
-char dltFifoBaseDir[PATH_MAX + 1] = "/tmp";
+char dltFifoBaseDir[DLT_PATH_MAX] = "/tmp";
 
 /* internal logging parameters */
 static int logging_mode = DLT_LOG_TO_CONSOLE;
@@ -1701,8 +1701,8 @@ void dlt_log_set_filename(const char *filename)
 
 void dlt_log_set_fifo_basedir(const char *env_pipe_dir)
 {
-    strncpy(dltFifoBaseDir, env_pipe_dir, PATH_MAX);
-    dltFifoBaseDir[PATH_MAX] = 0;
+    strncpy(dltFifoBaseDir, env_pipe_dir, DLT_PATH_MAX);
+    dltFifoBaseDir[DLT_PATH_MAX - 1] = 0;
 }
 
 void dlt_log_init(int mode)
@@ -2495,7 +2495,7 @@ int dlt_buffer_push3(DltBuffer *buf,
     }
 
     /* set header */
-    strncpy(head.head, DLT_BUFFER_HEAD, 3);
+    strncpy(head.head, DLT_BUFFER_HEAD, 4);
     head.head[3] = 0;
     head.status = 2;
     head.size = size1 + size2 + size3;

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -143,7 +143,7 @@ unsigned int dlt_offline_trace_storage_dir_info(char *path, char *file_name, cha
 void dlt_offline_trace_file_name(char *log_file_name, char *name, unsigned int idx)
 {
     char file_index[11]; /* UINT_MAX = 4294967295 -> 10 digits */
-    sprintf(file_index, "%010u", idx);
+    snprintf(file_index, sizeof(file_index), "%010u", idx);
 
     /* create log file name */
     memset(log_file_name, 0, DLT_OFFLINETRACE_FILENAME_MAX_SIZE * sizeof(char));


### PR DESCRIPTION
define DLT_PATH_MAX for max path buffer length

DLT limits the path length and does not do anything else to determine
the actual value, because the least that is supported on any system
that DLT runs on is 1024 bytes.

Signed-off-by: Vo Trung Chi <Chi.VoTrung@vn.bosch.com>
