### PR TITLE
Fix clang warning

### DIFF
--- a/src/console/dlt-control.c
+++ b/src/console/dlt-control.c
@@ -670,7 +670,7 @@ int dlt_receive_message_callback(DltMessage *message, void *data)
         return -1;
 
     /* to avoid warning */
-    data = data;
+    (void)data;
 
     /* prepare storage header */
     if (DLT_IS_HTYP_WEID(message->standardheader->htyp))

--- a/src/console/dlt-convert.c
+++ b/src/console/dlt-convert.c
@@ -343,7 +343,10 @@ int main(int argc, char *argv[])
 
                         if (end == (file.counter - 1)) {
                             /* Sleep if no new message was received */
-                            sleep(0.1);
+                            struct timespec req;
+                            req.tv_sec = 0;
+                            req.tv_nsec = 100000000;
+                            nanosleep(&req, NULL);
                         }
                         else {
                             /* set new end of log file and continue reading */

--- a/src/console/logstorage/dlt-logstorage-ctrl.c
+++ b/src/console/logstorage/dlt-logstorage-ctrl.c
@@ -163,8 +163,8 @@ static int analyze_response(char *data, void *payload, int len)
         return -1;
 
     /* satisfy compiler */
-    payload = payload;
-    len = len;
+    (void)payload;
+    (void)len;
 
     snprintf(resp_ok,
              MAX_RESPONSE_LENGTH,

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -829,8 +829,8 @@ int dlt_logstorage_sync_on_msg(DltLogStorageFilterConfig *config,
 {
     int ret;
 
-    file_config = file_config;  /* satisfy compiler */
-    dev_path = dev_path;
+    (void)file_config;  /* satisfy compiler */
+    (void)dev_path;
 
     if (config == NULL)
         return -1;
@@ -877,7 +877,7 @@ int dlt_logstorage_prepare_msg_cache(DltLogStorageFilterConfig *config,
         return -1;
     }
 
-    log_msg_size = log_msg_size; /* satisfy compiler */
+    (void)log_msg_size; /* satisfy compiler */
 
     /* check specific size is smaller than file size */
     if ((DLT_OFFLINE_LOGSTORAGE_IS_STRATEGY_SET(config->sync,

--- a/src/shared/dlt_config_file_parser.c
+++ b/src/shared/dlt_config_file_parser.c
@@ -239,7 +239,7 @@ static int dlt_config_file_set_section_data(DltConfigFile *file, char *str1, cha
  */
 static int dlt_config_file_line_has_section(char *line)
 {
-    line = line; /* avoid compiler warnings */
+    (void)line; /* avoid compiler warnings */
 
     if (line[0] == '[') /* section found */
         return 0;

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -147,10 +147,10 @@ void dlt_offline_trace_file_name(char *log_file_name, char *name, unsigned int i
 
     /* create log file name */
     memset(log_file_name, 0, DLT_OFFLINETRACE_FILENAME_MAX_SIZE * sizeof(char));
-    strncat(log_file_name, name, sizeof(DLT_OFFLINETRACE_FILENAME_BASE));
-    strncat(log_file_name, DLT_OFFLINETRACE_FILENAME_DELI, sizeof(DLT_OFFLINETRACE_FILENAME_DELI));
-    strncat(log_file_name, file_index, sizeof(file_index));
-    strncat(log_file_name, DLT_OFFLINETRACE_FILENAME_EXT, sizeof(DLT_OFFLINETRACE_FILENAME_EXT));
+    strncat(log_file_name, name, sizeof(log_file_name) - strlen(log_file_name) - 1);
+    strncat(log_file_name, DLT_OFFLINETRACE_FILENAME_DELI, sizeof(log_file_name) - strlen(log_file_name) - 1);
+    strncat(log_file_name, file_index, sizeof(log_file_name) - strlen(log_file_name) - 1);
+    strncat(log_file_name, DLT_OFFLINETRACE_FILENAME_EXT, sizeof(log_file_name) - strlen(log_file_name) - 1);
 }
 
 unsigned int dlt_offline_trace_get_idx_of_log_file(char *file)


### PR DESCRIPTION
mirror change for clang compiler warnings.
```console
$ mkdir build
$ cd build
$ cmake -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Debug -DWITH_DLT_TESTS=ON -DWITH_TESTSCRIPTS=ON -DWITH_DLT_UNIT_TESTS=ON -DWITH_SYSTEMD=ON -DWITH_SYSTEMD_JOURNAL=ON ..
$ make
```
 gtest_dlt_* are fine.