### PR TITLE
logstorage: fix compile error

### DIFF
--- a/src/console/logstorage/dlt-logstorage-common.c
+++ b/src/console/logstorage/dlt-logstorage-common.c
@@ -258,7 +258,7 @@ static DltControlMsgBody *prepare_message_body(DltControlMsgBody **body,
     DltServiceOfflineLogstorage *serv = NULL;
 
     if (path == NULL) {
-        pr_error("Mount path is uninitialized: %s\n", path);
+        pr_error("Mount path is uninitialized.\n");
         return NULL;
     }
 


### PR DESCRIPTION
Mount path unitialized and it is always NULL inside the statement.

Signed-off-by: jiripopek <Jiri.Popek@bmw.de>