### PR TITLE
Add user custom timestamp interface

### DIFF
--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -535,6 +535,37 @@ DLT_VERBOSE_MODE();
 DLT_NONVERBOSE_MODE();
 ```
 
+#### Using custom timestamps
+
+The timestamp that is transmitted in the header of a DLT message is usually generated automatically by the library itself right before the message is sent. If you wish to change this, e.g. because you want to indicate when an event occured, rather than when the according message was assembled, you can supply a custom timestamp. Compared to the example above, two macros are defined for convenience:
+
+```
+uint32_t timestamp = 1234567; /* uptime in 0.1 milliseconds */
+if (gflag) {
+    /* Non-verbose mode */
+    DLT_LOG_ID_TS(ctx, DLT_LOG_INFO, 42, timestamp,
+                  DLT_INT(num), DLT_STRING(text));
+}
+else {
+    /* Verbose mode */
+    DLT_LOG_TS(ctx, DLT_LOG_INFO, timestamp,
+               DLT_INT(num), DLT_STRING(text));
+}
+```
+
+If you wish to (or have to) use the function interface, you need to set the flag to make use of the user-supplied timestamp manually after calling dlt_user_log_write_start():
+
+
+```
+if (dlt_user_log_write_start(&ctx, &ctxdata, DLT_LOG_INFO) > 0) {
+    ctxdata.use_timestamp = DLT_USER_TIMESTAMP;
+    ctxdata.user_timestamp = (uint32_t) 1234567;
+    dlt_user_log_write_string(&myctxdata, "ID: ");
+    dlt_user_log_write_uint32(&myctxdata, 123);
+    dlt_user_log_write_finish(&myctxdata);
+}
+```
+
 ### Logging parameters
 
 The following parameter types can be used. Multiple parameters can be added to

--- a/include/dlt/dlt_types.h
+++ b/include/dlt/dlt_types.h
@@ -188,4 +188,13 @@ typedef enum
 } DltUserConnectionState;
 #endif
 
+/**
+ * Definition of timestamp types
+ */
+typedef enum
+{
+	DLT_AUTO_TIMESTAMP = 0,
+	DLT_USER_TIMESTAMP
+} DltTimestampType;
+
 #endif  /* DLT_TYPES_H */

--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -122,6 +122,8 @@ typedef struct
     int32_t trace_status;                         /**< trace status */
     int32_t args_num;                             /**< number of arguments for extended header*/
     char *context_description;                    /**< description of context */
+    DltTimestampType use_timestamp;               /**< whether to use user-supplied timestamps */
+    uint32_t user_timestamp;                      /**< user-supplied timestamp to use */
 } DltContextData;
 
 typedef struct

--- a/include/dlt/dlt_user_macros.h
+++ b/include/dlt/dlt_user_macros.h
@@ -69,6 +69,7 @@
 #define DLT_USER_MACROS_H
 
 #include "dlt_version.h"
+#include "dlt_types.h"
 
 /**
  * \defgroup userapi DLT User API
@@ -217,6 +218,35 @@
 #endif
 
 /**
+ * Send log message with variable list of messages (intended for verbose mode)
+ * @param CONTEXT object containing information about one special logging context
+ * @param LOGLEVEL the log level of the log message
+ * @param TS timestamp to be used for log message
+ * @param ARGS variable list of arguments
+ * @note To avoid the MISRA warning "The comma operator has been used outside a for statement"
+ *       use a semicolon instead of a comma to separate the ARGS.
+ *       Example: DLT_LOG_TS(hContext, DLT_LOG_INFO, timestamp, DLT_STRING("Hello world"); DLT_INT(123));
+ */
+#ifdef _MSC_VER
+/* DLT_LOG_TS is not supported by MS Visual C++ */
+/* use function interface instead            */
+#else
+#   define DLT_LOG_TS(CONTEXT, LOGLEVEL, TS, ARGS ...) \
+    do { \
+        DltContextData log_local; \
+        int dlt_local; \
+        dlt_local = dlt_user_log_write_start(&CONTEXT, &log_local, LOGLEVEL); \
+        if (dlt_local == DLT_RETURN_TRUE) \
+        { \
+            ARGS; \
+            log_local.use_timestamp = DLT_USER_TIMESTAMP; \
+            log_local.user_timestamp = (uint32_t) TS; \
+            (void)dlt_user_log_write_finish(&log_local); \
+        } \
+    } while (0)
+#endif
+
+/**
  * Send log message with variable list of messages (intended for non-verbose mode)
  * @param CONTEXT object containing information about one special logging context
  * @param LOGLEVEL the log level of the log message
@@ -240,6 +270,38 @@
         if (dlt_local == DLT_RETURN_TRUE) \
         { \
             ARGS; \
+            (void)dlt_user_log_write_finish(&log_local); \
+        } \
+    } while (0)
+#endif
+
+/**
+ * Send log message with variable list of messages (intended for non-verbose mode)
+ * @param CONTEXT object containing information about one special logging context
+ * @param LOGLEVEL the log level of the log message
+ * @param MSGID the message id of log message
+ * @param TS timestamp to be used for log message
+ * @param ARGS variable list of arguments:
+ * calls to DLT_STRING(), DLT_BOOL(), DLT_FLOAT32(), DLT_FLOAT64(),
+ * DLT_INT(), DLT_UINT(), DLT_RAW()
+ * @note To avoid the MISRA warning "The comma operator has been used outside a for statement"
+ *       use a semicolon instead of a comma to separate the ARGS.
+ *       Example: DLT_LOG_ID_TS(hContext, DLT_LOG_INFO, 0x1234, timestamp, DLT_STRING("Hello world"); DLT_INT(123));
+ */
+#ifdef _MSC_VER
+/* DLT_LOG_ID_TS is not supported by MS Visual C++ */
+/* use function interface instead               */
+#else
+#   define DLT_LOG_ID_TS(CONTEXT, LOGLEVEL, MSGID, TS, ARGS ...) \
+    do { \
+        DltContextData log_local; \
+        int dlt_local; \
+        dlt_local = dlt_user_log_write_start_id(&CONTEXT, &log_local, LOGLEVEL, MSGID); \
+        if (dlt_local == DLT_RETURN_TRUE) \
+        { \
+            ARGS; \
+            log_local.use_timestamp = DLT_USER_TIMESTAMP; \
+            log_local.user_timestamp = (uint32_t) TS; \
             (void)dlt_user_log_write_finish(&log_local); \
         } \
     } while (0)

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1538,6 +1538,7 @@ DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
     log->args_num = 0;
     log->log_level = loglevel;
     log->size = 0;
+    log->use_timestamp = DLT_AUTO_TIMESTAMP;
 
     /* In non-verbose mode, insert message id */
     if (dlt_user.verbose_mode == 0) {
@@ -3584,8 +3585,14 @@ DltReturnValue dlt_user_log_send_log(DltContextData *log, int mtype)
 
     /* Set header extra parameters */
     dlt_set_id(msg.headerextra.ecu, dlt_user.ecuID);
+
     /*msg.headerextra.seid = 0; */
-    msg.headerextra.tmsp = dlt_uptime();
+    if (log->use_timestamp == DLT_AUTO_TIMESTAMP) {
+        msg.headerextra.tmsp = dlt_uptime();
+    }
+    else {
+        msg.headerextra.tmsp = log->user_timestamp;
+    }
 
     if (dlt_message_set_extraparameters(&msg, 0) == DLT_RETURN_ERROR)
         return DLT_RETURN_ERROR;

--- a/src/system/dlt-system-options.c
+++ b/src/system/dlt-system-options.c
@@ -148,6 +148,7 @@ void init_configuration(DltSystemConfiguration *config)
     config->Journal.CurrentBoot = 1;
     config->Journal.Follow = 0;
     config->Journal.MapLogLevels = 1;
+    config->Journal.UseOriginalTimestamp = 1;
 
     /* File transfer */
     config->Filetransfer.Enable = 0;
@@ -288,6 +289,10 @@ int read_configuration_file(DltSystemConfiguration *config, char *file_name)
             else if (strcmp(token, "JournalMapLogLevels") == 0)
             {
                 config->Journal.MapLogLevels = atoi(value);
+            }
+            else if (strcmp(token, "JournalUseOriginalTimestamp") == 0)
+            {
+                config->Journal.UseOriginalTimestamp = atoi(value);
             }
 
             /* File transfer */

--- a/src/system/dlt-system.conf
+++ b/src/system/dlt-system.conf
@@ -74,6 +74,9 @@ JournalFollow = 0
 # 7       Debug 		DLT_LOG_DEBUG
 JournalMapLogLevels = 1
 
+# Use the original timestamp (uptime when the event actually occured) as DLT timestamp (Default: 1)
+JournalUseOriginalTimestamp = 1
+
 ########################################################################
 # Filetransfer Manager
 ########################################################################

--- a/src/system/dlt-system.h
+++ b/src/system/dlt-system.h
@@ -107,6 +107,7 @@ typedef struct {
     int CurrentBoot;
     int Follow;
     int MapLogLevels;
+    int UseOriginalTimestamp;
 } JournalOptions;
 
 typedef struct {

--- a/tests/gtest_dlt_user.cpp
+++ b/tests/gtest_dlt_user.cpp
@@ -452,6 +452,26 @@ TEST(t_dlt_user_log_write_finish, finish)
 }
 
 /*/////////////////////////////////////// */
+/* t_dlt_user_log_write_finish */
+TEST(t_dlt_user_log_write_finish, finish_with_timestamp)
+{
+    DltContext context;
+    DltContextData contextData;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_context(&context, "TEST", "dlt_user.c t_dlt_user_log_write_finish finish"));
+
+    /* finish with start and initialized context */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEFAULT));
+    contextData.use_timestamp = DLT_USER_TIMESTAMP;
+    contextData.user_timestamp = UINT32_MAX;
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+}
+
+/*/////////////////////////////////////// */
 /* t_dlt_user_log_write_bool */
 TEST(t_dlt_user_log_write_bool, normal)
 {


### PR DESCRIPTION
Two new macros are introduced so that users can use their customized
timestamps for DLT messages:
- DLT_LOG_TS(CONTEXT, LOGLEVEL, TS, ARGS ...)
- DLT_LOG_ID_TS(CONTEXT, LOGLEVEL, MSGID, TS, ARGS ...)
Detailed explanations can be found in dlt_for_developers.md.

Also a new option is added to dlt-system to use events' timestamps
from journald adapter.

Signed-off-by: Sebastian Unger <sunger@de.adit-jv.com>