### PR TITLE
dlt-system: Call tzset before localtime_r

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1464,6 +1464,7 @@ int dlt_daemon_control_message_timezone(int sock, DltDaemon *daemon, DltDaemonLo
 
     time_t t = time(NULL);
     struct tm lt;
+    tzset();
     localtime_r(&t, &lt);
 #if !defined(__CYGWIN__)
     resp->timezone = (int32_t)lt.tm_gmtoff;
@@ -2331,6 +2332,7 @@ int dlt_daemon_process_sixty_s_timer(DltDaemon *daemon,
 
         /*Added memset to avoid compiler warning for near initialization */
         memset((void *)&lt, 0, sizeof(lt));
+        tzset();
         localtime_r(&t, &lt);
 
         dlt_daemon_control_message_timezone(DLT_DAEMON_SEND_TO_ALL,

--- a/src/lib/dlt_filetransfer.c
+++ b/src/lib/dlt_filetransfer.c
@@ -180,6 +180,7 @@ void getFileCreationDate2(const char *file, int *ok, char *date)
     }
 
     *ok = 1;
+    tzset();
     localtime_r(&st.st_ctime, &ts);
     asctime_r(&ts, date);
 }

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -88,6 +88,7 @@ void dlt_logstorage_log_file_name(char *log_file_name,
         char stamp[DLT_OFFLINE_LOGSTORAGE_TIMESTAMP_LEN + 1] = { 0 };
         time_t t = time(NULL);
         struct tm tm_info;
+        tzset();
         localtime_r(&t, &tm_info);
         sprintf(stamp,
                 "%c%04d%02d%02d-%02d%02d%02d",

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -640,6 +640,7 @@ DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, int textlen
     if ((flags & DLT_HEADER_SHOW_TIME) == DLT_HEADER_SHOW_TIME) {
         /* print received time */
         time_t tt = msg->storageheader->seconds;
+        tzset();
         localtime_r(&tt, &timeinfo);
         strftime (buffer, sizeof(buffer), "%Y/%m/%d %H:%M:%S", &timeinfo);
         snprintf(text, textlength, "%s.%.6d ", buffer, msg->storageheader->microseconds);

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -186,6 +186,7 @@ DltReturnValue dlt_offline_trace_create_new_file(DltOfflineTrace *trace)
     if (trace->filenameTimestampBased) {
         int ret = 0;
         t = time(NULL);
+        tzset();
         localtime_r(&t, &tmp);
 
         strftime(outstr, sizeof(outstr), "%Y%m%d_%H%M%S", &tmp);

--- a/src/system/dlt-system-journal.c
+++ b/src/system/dlt-system-journal.c
@@ -165,6 +165,7 @@ void dlt_system_journal_get_timestamp(sd_journal *journal, MessageTimestamp *tim
     }
 
     time_secs = (time_t)(time_usecs / 1000000);
+    tzset();
     localtime_r(&time_secs, &timeinfo);
     strftime(buffer_realtime_formatted, sizeof(buffer_realtime_formatted), "%Y/%m/%d %H:%M:%S", &timeinfo);
 


### PR DESCRIPTION
Since localtime() was calling tzset() internally, it should be used
before localtime_r(). Refer to man page of localtime_r() for detail.

Signed-off-by: Saya Sugiura <ssugiura@jp.adit-jv.com>