### PR TITLE
dlt-control: Wait until send buffer is empty before exiting

### DIFF
--- a/src/console/dlt-control.c
+++ b/src/console/dlt-control.c
@@ -57,6 +57,7 @@
 #include <sys/stat.h>   /* for S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH */
 #include <fcntl.h>      /* for open() */
 #include <sys/uio.h>    /* for writev() */
+#include <sys/ioctl.h>  /* for ioctl(), SIOCOUTQ */
 #include <string.h>     /* for open() */
 
 #include "dlt_client.h"
@@ -111,6 +112,27 @@ typedef struct {
     DltFilter filter;
 } DltReceiveData;
 
+
+#ifdef __linux__
+void wait_send_buffer_empty(int fd)
+{
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 100000 * NANOSEC_PER_MILLISEC;
+
+    /* Wait until send buffer is empty */
+    while (1)
+    {
+        int unsent;
+        ioctl(fd, TIOCOUTQ, &unsent);
+        if (!unsent)
+        {
+            break;
+        }
+        nanosleep(&ts, NULL);
+    }
+}
+#endif
 
 /**
  * Print usage information of tool.
@@ -712,6 +734,11 @@ int main(int argc, char *argv[])
         ts.tv_sec = (dltdata.tvalue * NANOSEC_PER_MILLISEC) / NANOSEC_PER_SEC;
         ts.tv_nsec = (dltdata.tvalue * NANOSEC_PER_MILLISEC) % NANOSEC_PER_SEC;
         nanosleep(&ts, NULL);
+
+        /* Wait for all the data is sent to dlt-daemon */
+#ifdef __linux__
+        wait_send_buffer_empty(g_dltclient.sock);
+#endif
     }
 
     /* Dlt Client Cleanup */


### PR DESCRIPTION
By checking amount of unsent data in send buffer,
dlt-control will wait until send buffer is empty before exiting.
Thus, dlt-control ensure control message reaches to dlt-daemon.