### PR TITLE
libdlt: reattachment and improvement in dlt thread (#114)

### DIFF
--- a/doc/dlt_design_specification.txt
+++ b/doc/dlt_design_specification.txt
@@ -173,7 +173,7 @@ During unregister of application, the following things occur:
 
 ==== Handling of messages received from DLT daemon
 
-During receiver thread within the DLT user library checks for newly received messages from the DLT daemon, and handles them in the following way:
+During housekeeper thread within the DLT user library checks for newly received messages from the DLT daemon, and handles them in the following way:
 
 * DLT_USER_MESSAGE_LOG_LEVEL
 ** Store received log level and trace status for the received context to the context array

--- a/src/lib/dlt_user_cfg.h
+++ b/src/lib/dlt_user_cfg.h
@@ -123,8 +123,8 @@
 /* default message id for non-verbose mode, if no message id was provided */
 #define DLT_USER_DEFAULT_MSGID 0xffff
 
-/* delay for receiver thread (nsec) */
-#define DLT_USER_RECEIVE_NDELAY (100000000)
+/* delay for housekeeper thread (nsec) while receiving messages*/
+#define DLT_USER_RECEIVE_NDELAY (500 * 1000 * 1000)
 
 /* Name of environment variable for local print mode */
 #define DLT_USER_ENV_LOCAL_PRINT_MODE "DLT_LOCAL_PRINT_MODE"


### PR DESCRIPTION
Improvement: housekeeper thread with poll
- Change name receiver thread to housekeeper thread
- Use poll() in housekeeper thread to get new received message
  from DLT Daemon.
- Remove resend buffer inside of dlt_user_log_reattach_to_daemon()
- Only try to resend buffer if fd is valid.

This commit removes the event driven dlt_user_log_reattach_to_daemon()
that is called e.g. by DLT_LOG. Now, only the DLT housekeeper thread
handles the retrial to attach to daemon.

Signed-off-by: Vo Trung Chi <Chi.VoTrung@vn.bosch.com>
Signed-off-by: Saya Sugiura <ssugiura@jp.adit-jv.com>
Signed-off-by: Simon Herkenhoff <sherkenhoff@jp.adit-jv.com>
Signed-off-by: Bui Nguyen Quoc Thanh <Thanh.BuiNguyenQuoc@vn.bosch.com>