### PR TITLE
Enable offline trace if "OfflineTraceDirectory" & "OfflineTraceOn" option is set

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -247,6 +247,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     /* set default values for configuration */
     daemon_local->flags.sharedMemorySize = DLT_SHM_SIZE;
     daemon_local->flags.sendMessageTime = 0;
+    daemon_local->flags.offlineTraceOn = 0;
     daemon_local->flags.offlineTraceDirectory[0] = 0;
     daemon_local->flags.offlineTraceFileSize = 1000000;
     daemon_local->flags.offlineTraceMaxSize = 0;
@@ -454,6 +455,11 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                     else if (strcmp(token, "SharedMemorySize") == 0)
                     {
                         daemon_local->flags.sharedMemorySize = atoi(value);
+                        /*printf("Option: %s=%s\n",token,value); */
+                    }
+                    else if (strcmp(token, "OfflineTraceOn") == 0)
+                    {
+                        daemon_local->flags.offlineTraceOn = atoi(value);
                         /*printf("Option: %s=%s\n",token,value); */
                     }
                     else if (strcmp(token, "OfflineTraceDirectory") == 0)
@@ -1000,7 +1006,8 @@ int dlt_daemon_local_init_p2(DltDaemon *daemon, DltDaemonLocal *daemon_local, in
                         daemon_local->flags.contextLogLevel,
                         daemon_local->flags.contextTraceStatus,
                         (daemon_local->flags.offlineTraceDirectory[0] !=
-                         '\0') ? DLT_USER_MODE_BOTH : DLT_USER_MODE_EXTERNAL,
+                         '\0') &&
+                        (daemon_local->flags.offlineTraceOn != 0) ? DLT_USER_MODE_BOTH : DLT_USER_MODE_EXTERNAL,
                         daemon_local->flags.enforceContextLLAndTS,
                         daemon_local->flags.vflag) == -1) {
         dlt_log(LOG_ERR, "Could not initialize daemon data\n");

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -148,8 +148,10 @@ int option_handling(DltDaemonLocal *daemon_local, int argc, char *argv[])
     opterr = 0;
 
 #ifdef DLT_SHM_ENABLE
+
     while ((c = getopt (argc, argv, "hdc:t:s:p:")) != -1)
 #else
+
     while ((c = getopt (argc, argv, "hdc:t:p:")) != -1)
 #endif
         switch (c) {
@@ -282,6 +284,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     if (strlen(DLT_USER_IPC_PATH) > DLT_IPC_PATH_MAX)
         fprintf(stderr, "Provided path too long...trimming it to path[%s]\n",
                 daemon_local->flags.appSockPath);
+
 #else
     memset(daemon_local->flags.daemonFifoGroup, 0, sizeof(daemon_local->flags.daemonFifoGroup));
 #endif
@@ -601,8 +604,9 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                                     intval);
                         }
                     }
+
 #ifndef DLT_USE_UNIX_SOCKET_IPC
-                    else if(strcmp(token, "DaemonFifoGroup") == 0)
+                    else if (strcmp(token, "DaemonFifoGroup") == 0)
                     {
                         strncpy(daemon_local->flags.daemonFifoGroup, value, NAME_MAX);
                         daemon_local->flags.daemonFifoGroup[NAME_MAX] = 0;
@@ -1038,13 +1042,13 @@ int dlt_daemon_local_init_p2(DltDaemon *daemon, DltDaemonLocal *daemon_local, in
 
     /* init shared memory */
     if (dlt_shm_init_server(&(daemon_local->dlt_shm), daemon_local->flags.dltShmName,
-        daemon_local->flags.sharedMemorySize) == DLT_RETURN_ERROR)
-    {
+                            daemon_local->flags.sharedMemorySize) == DLT_RETURN_ERROR) {
         dlt_log(LOG_ERR, "Could not initialize shared memory\n");
         return -1;
     }
 
     daemon_local->recv_buf_shm = (unsigned char *)calloc(1, DLT_SHM_RCV_BUFFER_SIZE);
+
     if (NULL == daemon_local->recv_buf_shm) {
         dlt_log(LOG_ERR, "failed to allocated the buffer to receive shm data\n");
         return -1;
@@ -1163,19 +1167,17 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
     } /* if */
 
     /* Set group of daemon FIFO */
-    if (daemon_local->flags.daemonFifoGroup[0] != 0)
-    {
+    if (daemon_local->flags.daemonFifoGroup[0] != 0) {
         errno = 0;
-        struct group * group_dlt = getgrnam(daemon_local->flags.daemonFifoGroup);
-        if (group_dlt)
-        {
+        struct group *group_dlt = getgrnam(daemon_local->flags.daemonFifoGroup);
+
+        if (group_dlt) {
             ret = chown(tmpFifo, -1, group_dlt->gr_gid);
+
             if (ret == -1)
-            {
                 dlt_vlog(LOG_ERR, "FIFO user %s cannot be chowned to group %s (%s)\n",
                          tmpFifo, daemon_local->flags.daemonFifoGroup,
                          strerror(errno));
-            }
         }
         else if ((errno == 0) || (errno == ENOENT) || (errno == EBADF) || (errno == EPERM))
         {
@@ -1183,8 +1185,7 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
                      daemon_local->flags.daemonFifoGroup,
                      strerror(errno));
         }
-        else
-        {
+        else {
             dlt_vlog(LOG_ERR, "Failed to get group id of %s (%s)\n",
                      daemon_local->flags.daemonFifoGroup,
                      strerror(errno));
@@ -1201,18 +1202,15 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
 
     if (daemon_local->daemonFifoSize != 0) {
         /* Set Daemon FIFO size */
-        if (fcntl(fd, F_SETPIPE_SZ, daemon_local->daemonFifoSize) == -1) {
+        if (fcntl(fd, F_SETPIPE_SZ, daemon_local->daemonFifoSize) == -1)
             dlt_vlog(LOG_ERR, "set FIFO size error: %s\n", strerror(errno));
-        }
     }
 
     /* Get Daemon FIFO size */
-    if ((fifo_size = fcntl(fd, F_GETPIPE_SZ, 0)) == -1) {
+    if ((fifo_size = fcntl(fd, F_GETPIPE_SZ, 0)) == -1)
         dlt_vlog(LOG_ERR, "get FIFO size error: %s\n", strerror(errno));
-    }
-    else {
+    else
         dlt_vlog(LOG_INFO, "FIFO size: %d\n", fifo_size);
-    }
 
     /* Early init, to be able to catch client (app) connections
      * as soon as possible. This registration is automatically ignored
@@ -1982,9 +1980,8 @@ int dlt_daemon_process_control_connect(
         return -1;
     }
 
-    if (verbose) {
+    if (verbose)
         dlt_vlog(LOG_INFO, "New connection to control client established\n");
-    }
 
     return 0;
 }
@@ -2032,9 +2029,8 @@ int dlt_daemon_process_app_connect(
         return -1;
     }
 
-    if (verbose) {
+    if (verbose)
         dlt_vlog(LOG_INFO, "New connection to application established\n");
-    }
 
     return 0;
 }
@@ -2381,7 +2377,8 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
                  userapp.apid, userapp.pid);
         return -1;
     }
-    else if (old_pid != application->pid) {
+    else if (old_pid != application->pid)
+    {
         char local_str[DLT_DAEMON_TEXTBUFSIZE] = { '\0' };
 
         snprintf(local_str,
@@ -2731,7 +2728,7 @@ int dlt_daemon_process_user_message_unregister_context(DltDaemon *daemon,
      * unregisters, the context information will not be deleted from daemon's
      * table until its parent application is unregistered.
      */
-    if (context && context->predefined == false) {
+    if (context && (context->predefined == false)) {
         /* Delete this connection entry from internal table*/
         if (dlt_daemon_context_del(daemon, context, daemon->ecuid, verbose) == -1) {
             dlt_vlog(LOG_WARNING,
@@ -2789,6 +2786,7 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
     }
 
 #ifdef DLT_SHM_ENABLE
+
     /** In case of SHM, the header still received via fifo/unix_socket receiver,
      * so we need to remove header from the receiver.
      */
@@ -2815,10 +2813,12 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
         }
 
         ret = dlt_daemon_client_send_message_to_all_client(daemon,
-                                                daemon_local, verbose);
+                                                           daemon_local, verbose);
+
         if (DLT_DAEMON_ERROR_OK != ret)
             dlt_log(LOG_ERR, "failed to send message to client.\n");
     }
+
 #else
     ret = dlt_message_read(&(daemon_local->msg),
                            (unsigned char *)rec->buf + sizeof(DltUserHeader),
@@ -2841,7 +2841,8 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
     }
 
     ret = dlt_daemon_client_send_message_to_all_client(daemon,
-                                            daemon_local, verbose);
+                                                       daemon_local, verbose);
+
     if (DLT_DAEMON_ERROR_OK != ret)
         dlt_log(LOG_ERR, "failed to send message to client\n");
 
@@ -2857,6 +2858,7 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
         dlt_log(LOG_WARNING, "failed to remove bytes from receiver.\n");
         return DLT_DAEMON_ERROR_UNKNOWN;
     }
+
 #endif
 
     return DLT_DAEMON_ERROR_OK;
@@ -3112,10 +3114,9 @@ int create_timer_fd(DltDaemonLocal *daemon_local,
         struct itimerspec l_timer_spec;
         local_fd = timerfd_create(CLOCK_MONOTONIC, 0);
 
-        if (local_fd < 0) {
+        if (local_fd < 0)
             dlt_vlog(LOG_WARNING, "<%s> timerfd_create failed: %s\n",
                      timer_name, strerror(errno));
-        }
 
         l_timer_spec.it_interval.tv_sec = period_sec;
         l_timer_spec.it_interval.tv_nsec = 0;
@@ -3133,10 +3134,9 @@ int create_timer_fd(DltDaemonLocal *daemon_local,
     /* If fully initialized we are done.
      * Event handling registration is done later on with other connections.
      */
-    if (local_fd > 0) {
+    if (local_fd > 0)
         dlt_vlog(LOG_INFO, "<%s> initialized with %d timer\n", timer_name,
                  period_sec);
-    }
 
     return dlt_connection_create(daemon_local,
                                  &daemon_local->pEvent,

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -998,7 +998,10 @@ int dlt_daemon_local_init_p2(DltDaemon *daemon, DltDaemonLocal *daemon_local, in
     if (dlt_daemon_init(daemon, daemon_local->RingbufferMinSize, daemon_local->RingbufferMaxSize,
                         daemon_local->RingbufferStepSize, daemon_local->flags.ivalue,
                         daemon_local->flags.contextLogLevel,
-                        daemon_local->flags.contextTraceStatus, daemon_local->flags.enforceContextLLAndTS,
+                        daemon_local->flags.contextTraceStatus,
+                        (daemon_local->flags.offlineTraceDirectory[0] !=
+                         '\0') ? DLT_USER_MODE_BOTH : DLT_USER_MODE_EXTERNAL,
+                        daemon_local->flags.enforceContextLLAndTS,
                         daemon_local->flags.vflag) == -1) {
         dlt_log(LOG_ERR, "Could not initialize daemon data\n");
         return -1;

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -101,6 +101,7 @@ typedef struct
     int sharedMemorySize;        /**< (int) Size of shared memory (Default: 100000) */
     int sendMessageTime;        /**< (Boolean) Send periodic Message Time if client is connected (Default: 0) */
     char offlineTraceDirectory[DLT_DAEMON_FLAG_MAX]; /**< (String: Directory) Store DLT messages to local directory (Default: /etc/dlt.conf) */
+    int offlineTraceOn; /**< (int) Enable offline tracing if offlineTraceDirectory is set */
     int offlineTraceFileSize;     /**< (int) Maximum size in bytes of one trace file (Default: 1000000) */
     int offlineTraceMaxSize;     /**< (int) Maximum size of all trace files (Default: 4000000) */
     int offlineTraceFilenameTimestampBased;  /**< (int) timestamp based or index based (Default: 1 Timestamp based) */

--- a/src/daemon/dlt.conf
+++ b/src/daemon/dlt.conf
@@ -97,6 +97,9 @@ ControlSocketPath = /tmp/dlt-ctrl.sock
 # Offline Trace memory                                                 #
 ########################################################################
 
+# Enable/Disable OfflineTrace into directory "OfflineTraceDirectory" if set (Default: off) 
+# OfflineTraceOn = 0
+
 # Store DLT messages to local directory, if not set offline Trace is off (Default: off)
 # OfflineTraceDirectory = /tmp
 

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -206,6 +206,7 @@ int dlt_daemon_init(DltDaemon *daemon,
                     const char *runtime_directory,
                     int InitialContextLogLevel,
                     int InitialContextTraceStatus,
+                    DltUserLogMode UserLogMode,
                     int ForceLLTS,
                     int verbose)
 {
@@ -225,7 +226,7 @@ int dlt_daemon_init(DltDaemon *daemon,
 
     daemon->runtime_context_cfg_loaded = 0;
 
-    daemon->mode = DLT_USER_MODE_EXTERNAL;
+    daemon->mode = UserLogMode;
 
     daemon->connectionState = 0; /* no logger connected */
 

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -373,8 +373,6 @@ int dlt_daemon_applications_clear(DltDaemon *daemon, char *ecu, int verbose)
             user_list->applications[i].application_description = NULL;
         }
 
-
-
     if (user_list->applications != NULL)
         free(user_list->applications);
 
@@ -1060,8 +1058,6 @@ int dlt_daemon_contexts_clear(DltDaemon *daemon, char *ecu, int verbose)
             users->contexts[i].context_description = NULL;
         }
 
-
-
     if (users->contexts) {
         free(users->contexts);
         users->contexts = NULL;
@@ -1496,12 +1492,11 @@ void dlt_daemon_user_send_default_update(DltDaemon *daemon, int verbose)
         if (context != NULL) {
             if ((context->log_level == DLT_LOG_DEFAULT) ||
                 (context->trace_status == DLT_TRACE_STATUS_DEFAULT)) {
-                if (context->user_handle >= DLT_FD_MINIMUM) {
+                if (context->user_handle >= DLT_FD_MINIMUM)
                     if (dlt_daemon_user_send_log_level(daemon,
                                                        context,
                                                        verbose) == -1)
                         dlt_vlog(LOG_WARNING, "Cannot update default of %.4s:%.4s\n", context->apid, context->ctid);
-                }
             }
         }
     }
@@ -1601,10 +1596,9 @@ void dlt_daemon_user_send_all_log_state(DltDaemon *daemon, int verbose)
         app = &(user_list->applications[count]);
 
         if (app != NULL) {
-            if (app->user_handle >= DLT_FD_MINIMUM) {
+            if (app->user_handle >= DLT_FD_MINIMUM)
                 if (dlt_daemon_user_send_log_state(daemon, app, verbose) == -1)
                     dlt_vlog(LOG_WARNING, "Cannot send log state to Apid: %.4s, PID: %d\n", app->apid, app->pid);
-            }
         }
     }
 }

--- a/src/daemon/dlt_daemon_common.h
+++ b/src/daemon/dlt_daemon_common.h
@@ -201,6 +201,7 @@ typedef struct
  * @param runtime_directory Directory of persistent configuration
  * @param InitialContextLogLevel loglevel to be sent to context when those register with loglevel default, read from dlt.conf
  * @param InitialContextTraceStatus tracestatus to be sent to context when those register with tracestatus default, read from dlt.conf
+ * @param UserLogMode DLT_USER_LOG_(OFF|INTERNAL|EXTERNAL|BOTH)
  * @param ForceLLTS force default log-level
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
@@ -212,6 +213,7 @@ int dlt_daemon_init(DltDaemon *daemon,
                     const char *runtime_directory,
                     int InitialContextLogLevel,
                     int InitialContextTraceStatus,
+                    DltUserLogMode UserLogMode,
                     int ForceLLTS,
                     int verbose);
 /**

--- a/src/daemon/dlt_daemon_common.h
+++ b/src/daemon/dlt_daemon_common.h
@@ -96,12 +96,12 @@ extern "C" {
 
 /* Use a semaphore or mutex from your OS to prevent concurrent access to the DLT buffer. */
 
-#define DLT_DAEMON_SEM_LOCK() do{\
-    while ((sem_wait(&dlt_daemon_mutex) == -1) && (errno == EINTR)) \
-        continue;       /* Restart if interrupted */ \
-    } while(0)
+#   define DLT_DAEMON_SEM_LOCK() do { \
+        while ((sem_wait(&dlt_daemon_mutex) == -1) && (errno == EINTR)) \
+            continue;   /* Restart if interrupted */ \
+} while (0)
 
-#define DLT_DAEMON_SEM_FREE() { sem_post(&dlt_daemon_mutex); }
+#   define DLT_DAEMON_SEM_FREE() { sem_post(&dlt_daemon_mutex); }
 extern sem_t dlt_daemon_mutex;
 
 /* UDPMulticart Default IP and Port */

--- a/tests/gtest_dlt_daemon_common.cpp
+++ b/tests/gtest_dlt_daemon_common.cpp
@@ -64,7 +64,8 @@ TEST(t_dlt_daemon_init_user_information, normal_one_list)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -93,7 +94,8 @@ TEST(t_dlt_daemon_init_user_information, normal_multiple_lists)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
 
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 1, 0));
@@ -130,7 +132,8 @@ TEST(t_dlt_daemon_find_users_list, normal_one_list)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
 
@@ -155,7 +158,8 @@ TEST(t_dlt_daemon_find_users_list, abnormal)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
 
@@ -187,7 +191,8 @@ TEST(t_dlt_daemon_find_users_list, normal_multiple_lists)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
 
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 1, 0));
@@ -238,7 +243,7 @@ TEST(t_dlt_daemon_application_add, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -345,7 +350,7 @@ TEST(t_dlt_daemon_application_del, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -413,7 +418,7 @@ TEST(t_dlt_daemon_application_find, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -481,7 +486,7 @@ TEST(t_dlt_daemon_applications_clear, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -531,7 +536,7 @@ TEST(t_dlt_daemon_applications_invalidate_fd, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -587,7 +592,7 @@ TEST(t_dlt_daemon_applications_save, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -650,7 +655,7 @@ TEST(t_dlt_daemon_applications_load, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -737,7 +742,7 @@ TEST(t_dlt_daemon_context_add, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -772,7 +777,7 @@ TEST(t_dlt_daemon_context_add, abnormal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -900,7 +905,7 @@ TEST(t_dlt_daemon_context_add, nullpointer)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -942,7 +947,7 @@ TEST(t_dlt_daemon_context_del, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1032,7 +1037,7 @@ TEST(t_dlt_daemon_context_find, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1074,7 +1079,7 @@ TEST(t_dlt_daemon_context_find, abnormal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1182,7 +1187,7 @@ TEST(t_dlt_daemon_contexts_clear, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1252,7 +1257,7 @@ TEST(t_dlt_daemon_contexts_invalidate_fd, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1325,7 +1330,7 @@ TEST(t_dlt_daemon_contexts_save, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1413,7 +1418,7 @@ TEST(t_dlt_daemon_contexts_load, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1503,7 +1508,7 @@ TEST(t_dlt_daemon_user_send_all_log_state, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1533,7 +1538,7 @@ TEST(t_dlt_daemon_user_send_default_update, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1568,7 +1573,7 @@ TEST(t_dlt_daemon_user_send_log_level, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));
@@ -1656,7 +1661,7 @@ TEST(t_dlt_daemon_user_send_log_state, normal)
     EXPECT_EQ(0,
               dlt_daemon_init(&daemon, DLT_DAEMON_RINGBUFFER_MIN_SIZE, DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                               DLT_DAEMON_RINGBUFFER_STEP_SIZE, DLT_RUNTIME_DEFAULT_DIRECTORY, DLT_LOG_INFO,
-                              DLT_TRACE_STATUS_OFF, 0, 0));
+                              DLT_TRACE_STATUS_OFF, DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, strncmp(daemon.ecuid, daemon.user_list[0].ecu, DLT_ID_SIZE));

--- a/tests/gtest_dlt_daemon_offline_log.cpp
+++ b/tests/gtest_dlt_daemon_offline_log.cpp
@@ -38,7 +38,7 @@ TEST(t_dlt_logstorage_list_add, normal)
     DltLogStorageFilterList *list = NULL;
     DltLogStorageFilterConfig *data = NULL;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     char key = 1;
     int num_keys = 1;
 
@@ -74,7 +74,7 @@ TEST(t_dlt_logstorage_list_destroy, normal)
     DltLogStorageFilterList *list = NULL;
     DltLogStorageFilterConfig *data = NULL;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     char key = 1;
     int num_keys = 1;
 
@@ -95,7 +95,7 @@ TEST(t_dlt_logstorage_list_find, normal)
     DltLogStorageFilterConfig *data = NULL;
     int num_configs = 0;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     char key[] = ":1234:5678";
     char apid[] = "1234";
     char ctid[] = "5678";
@@ -196,7 +196,7 @@ TEST(t_dlt_logstorage_prepare_table, normal)
     DltLogStorage handle;
     DltLogStorageFilterConfig data;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     memset(&handle, 0, sizeof(DltLogStorage));
     memset(&data, 0, sizeof(DltLogStorageFilterConfig));
     char apids[] = "1234";
@@ -447,7 +447,7 @@ TEST(t_dlt_logstorage_store_filters, normal)
 {
     DltLogStorage handle;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     char config_file_name[] = "/tmp/dlt_logstorage.conf";
     handle.connection_type = DLT_OFFLINE_LOGSTORAGE_DEVICE_CONNECTED;
     handle.config_status = 0;
@@ -469,7 +469,7 @@ TEST(t_dlt_logstorage_load_config, normal)
 {
     DltLogStorage handle;
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
     handle.connection_type = DLT_OFFLINE_LOGSTORAGE_DEVICE_CONNECTED;
     handle.config_status = 0;
     handle.write_errors = 0;
@@ -933,7 +933,7 @@ TEST(t_dlt_logstorage_write_on_msg, normal)
 
     EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_prepare_on_msg(&config, &file_config, path, 1));
     EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_write_on_msg(&config, &file_config, path,
-              data1, size, data2, size, data3, size));
+                                                         data1, size, data2, size, data3, size));
 }
 
 TEST(t_dlt_logstorage_write_on_msg, null)
@@ -1006,14 +1006,14 @@ TEST(t_dlt_logstorage_write_msg_cache, normal)
     DltLogStorageFilterConfig config;
     memset(&config, 0, sizeof(DltLogStorageFilterConfig));
     DltLogStorageUserConfig file_config;
-    char *path = (char*)"/tmp";
+    char *path = (char *)"/tmp";
 
     config.cache = calloc(1, 50 + sizeof(DltLogStorageCacheFooter));
 
     if (config.cache != NULL) {
         config.file_size = 50;
         EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_write_msg_cache(&config, &file_config, path,
-                  data1, size, data2, size, data3, size));
+                                                                data1, size, data2, size, data3, size));
 
         free(config.cache);
         config.cache = NULL;
@@ -1510,7 +1510,7 @@ TEST(t_dlt_logstorage_find_dlt_header, null)
 /* Begin Method: dlt_logstorage::t_dlt_logstorage_find_last_dlt_header*/
 TEST(t_dlt_logstorage_find_last_dlt_header, normal)
 {
-    char data[] = {'a','b','D','L','T',0x01};
+    char data[] = { 'a', 'b', 'D', 'L', 'T', 0x01 };
     DltLogStorageFilterConfig config;
     memset(&config, 0, sizeof(DltLogStorageFilterConfig));
     config.cache = calloc(1, sizeof(data));
@@ -1525,12 +1525,12 @@ TEST(t_dlt_logstorage_find_last_dlt_header, normal)
 }
 TEST(t_dlt_logstorage_find_last_dlt_header, null)
 {
-    char data[] = {'N','o','H','e','a','d','e','r'};
+    char data[] = { 'N', 'o', 'H', 'e', 'a', 'd', 'e', 'r' };
     DltLogStorageFilterConfig config;
     memset(&config, 0, sizeof(DltLogStorageFilterConfig));
     config.cache = calloc(1, sizeof(data));
-    if (config.cache != NULL)
-    {
+
+    if (config.cache != NULL) {
         /* config.cache =(void *) "a,b,D,L,T,0x01"; */
         strncpy((char *)config.cache, data, sizeof(data));
         EXPECT_EQ(-1, dlt_logstorage_find_last_dlt_header(config.cache, 0, sizeof(data)));
@@ -1573,12 +1573,12 @@ TEST(t_dlt_logstorage_sync_to_file, normal)
     if (config.cache != NULL) {
         EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_prepare_msg_cache(&config, &file_config, path, 1));
         EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_write_msg_cache(&config, &file_config, path,
-                  data1, size, data2, size, data3, size));
+                                                                data1, size, data2, size, data3, size));
 
-        footer = (DltLogStorageCacheFooter *)((uint8_t*)config.cache + config.file_size);
+        footer = (DltLogStorageCacheFooter *)((uint8_t *)config.cache + config.file_size);
 
         EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_sync_to_file(&config, &file_config, path,
-                  footer, footer->last_sync_offset, footer->offset));
+                                                             footer, footer->last_sync_offset, footer->offset));
         free(config.cache);
         config.cache = NULL;
     }
@@ -1625,7 +1625,8 @@ TEST(t_dlt_logstorage_sync_msg_cache, normal)
 
     if (config.cache != NULL) {
         EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_prepare_msg_cache(&config, &file_config, path, 1));
-        EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_write_msg_cache(&config, &file_config, path, data1, size, data2, size, data3, size));
+        EXPECT_EQ(DLT_RETURN_OK,
+                  dlt_logstorage_write_msg_cache(&config, &file_config, path, data1, size, data2, size, data3, size));
         EXPECT_EQ(DLT_RETURN_OK,
                   dlt_logstorage_sync_msg_cache(&config, &file_config, path, DLT_LOGSTORAGE_SYNC_ON_DEMAND));
         free(config.cache);
@@ -1647,7 +1648,7 @@ int connectServer(void)
     portno = 8080;
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     server = gethostbyname("127.0.0.1");
-    memset((char *) &serv_addr, 0, sizeof(serv_addr));
+    memset((char *)&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
     memcpy((char *)&serv_addr.sin_addr.s_addr,
            (char *)server->h_addr,
@@ -1659,6 +1660,7 @@ int connectServer(void)
         close(sockfd);
         return -1;
     }
+
 #else
     char filename[1024];
     int sockfd;
@@ -1701,7 +1703,7 @@ int main(int argc, char **argv)
             return -1;
         }
 
-        memset((char *) &serv_addr, 0, sizeof(serv_addr));
+        memset((char *)&serv_addr, 0, sizeof(serv_addr));
         portno = 8080;
 
         serv_addr.sin_family = AF_INET;
@@ -1745,12 +1747,12 @@ int main(int argc, char **argv)
     }
     else {
 #endif
-        ::testing::InitGoogleTest(&argc, argv);
-        ::testing::FLAGS_gtest_break_on_failure = false;
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::FLAGS_gtest_break_on_failure = false;
 /*        ::testing::FLAGS_gtest_filter = "t_dlt_event_handler_register_connection*"; */
-        return RUN_ALL_TESTS();
+    return RUN_ALL_TESTS();
 #ifdef DLT_USE_UNIX_SOCKET_IPC
-    }
+}
 #endif
 
     return 0;

--- a/tests/gtest_dlt_daemon_offline_log.cpp
+++ b/tests/gtest_dlt_daemon_offline_log.cpp
@@ -1068,7 +1068,8 @@ TEST(t_dlt_logstorage_update_all_contexts, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
     EXPECT_EQ(DLT_RETURN_OK, dlt_logstorage_update_all_contexts(&daemon, &daemon_local, apid, 1, 1, ecu, 0));
@@ -1108,7 +1109,8 @@ TEST(t_dlt_logstorage_update_context, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
     app = dlt_daemon_application_add(&daemon, apid, getpid(), desc, fd, ecu, 0);
@@ -1153,7 +1155,8 @@ TEST(t_dlt_logstorage_update_context_loglevel, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
     app = dlt_daemon_application_add(&daemon, apid, getpid(), desc, fd, ecu, 0);
@@ -1190,7 +1193,8 @@ TEST(t_dlt_daemon_logstorage_reset_application_loglevel, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
     EXPECT_NO_THROW(dlt_daemon_logstorage_reset_application_loglevel(&daemon, &daemon_local, device_index, 1, 0));
@@ -1232,7 +1236,8 @@ TEST(t_dlt_daemon_logstorage_get_loglevel, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
 
@@ -1285,7 +1290,8 @@ TEST(t_dlt_daemon_logstorage_update_application_loglevel, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));
 
@@ -1319,7 +1325,8 @@ TEST(t_dlt_daemon_logstorage_write, normal)
                                  DLT_DAEMON_RINGBUFFER_MAX_SIZE,
                                  DLT_DAEMON_RINGBUFFER_STEP_SIZE,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &gateway, 0, 0));
     daemon.storage_handle = &storage_handle;
@@ -1381,7 +1388,8 @@ TEST(t_dlt_daemon_logstorage_setup_internal_storage, normal)
                                  daemon_local.RingbufferMaxSize,
                                  daemon_local.RingbufferStepSize,
                                  DLT_RUNTIME_DEFAULT_DIRECTORY,
-                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF, 0, 0));
+                                 DLT_LOG_INFO, DLT_TRACE_STATUS_OFF,
+                                 DLT_USER_MODE_EXTERNAL, 0, 0));
 
     dlt_set_id(daemon.ecuid, ecu);
     EXPECT_EQ(0, dlt_daemon_init_user_information(&daemon, &daemon_local.pGateway, 0, 0));


### PR DESCRIPTION
Instead of DLT_USER_MODE_EXTERNAL set the UserLogMode to DLT_USER_MODE_BOTH 
when "OfflineTraceDirectory" and "OfflibeTraceOn" is set in dlt.log

Some artifacts generated by  uncriustify

Signed-off-by: Sebastian Kloska <sebastian.kloska@snafu.de>