### PR TITLE
libdlt: Fix message lost issue at exit

### DIFF
--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -190,6 +190,7 @@ typedef struct
 {
     char ecuID[DLT_ID_SIZE];                   /**< ECU ID */
     char appID[DLT_ID_SIZE];                   /**< Application ID */
+    char appID_atexit[DLT_ID_SIZE];            /**< Application ID for atexit */
     int dlt_log_handle;                        /**< Handle to fifo of dlt daemon */
     int dlt_user_handle;                       /**< Handle to own fifo */
     mqd_t dlt_segmented_queue_read_handle;     /**< Handle message queue */


### PR DESCRIPTION
If messages are stored to buffer in user library and dlt_unregister_app() is
called before exit, message lost occurred due to missing appID.

Change-Id: I1aef367fef4e14027114cf8c7e58e65fda6763eb