### PR TITLE
dlt-offline-trace: fix bug and hardcode (#174)

### DIFF
--- a/include/dlt/dlt_offline_trace.h
+++ b/include/dlt/dlt_offline_trace.h
@@ -60,15 +60,9 @@
 #include "dlt_types.h"
 
 #define DLT_OFFLINETRACE_FILENAME_BASE "dlt_offlinetrace"
-#define DLT_OFFLINETRACE_FILENAME_DELI "."
+#define DLT_OFFLINETRACE_FILENAME_INDEX_DELI "."
+#define DLT_OFFLINETRACE_FILENAME_TIMESTAMP_DELI "_"
 #define DLT_OFFLINETRACE_FILENAME_EXT  ".dlt"
-#define DLT_OFFLINETRACE_INDEX_MAX_SIZE 10
-#define DLT_OFFLINETRACE_FILENAME_TO_COMPARE "dlt_offlinetrace_"
-/* "dlt_offlinetrace.4294967295.dlt" -> MAX 32byte include NULL terminate */
-#define DLT_OFFLINETRACE_FILENAME_MAX_SIZE   (sizeof(DLT_OFFLINETRACE_FILENAME_BASE) + \
-                                              sizeof(DLT_OFFLINETRACE_FILENAME_DELI) + \
-                                              DLT_OFFLINETRACE_INDEX_MAX_SIZE + \
-                                              sizeof(DLT_OFFLINETRACE_FILENAME_EXT) + 1)
 
 typedef struct
 {

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -249,7 +249,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     daemon_local->flags.sendMessageTime = 0;
     daemon_local->flags.offlineTraceDirectory[0] = 0;
     daemon_local->flags.offlineTraceFileSize = 1000000;
-    daemon_local->flags.offlineTraceMaxSize = 0;
+    daemon_local->flags.offlineTraceMaxSize = 4000000;
     daemon_local->flags.offlineTraceFilenameTimestampBased = 1;
     daemon_local->flags.loggingMode = DLT_LOG_TO_CONSOLE;
     daemon_local->flags.loggingLevel = LOG_INFO;
@@ -267,7 +267,6 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     daemon_local->flags.sendTimezone = 0;
     daemon_local->flags.offlineLogstorageMaxDevices = 0;
     daemon_local->flags.offlineLogstorageDirPath[0] = 0;
-    daemon_local->flags.offlineLogstorageMaxDevices = 0;
     daemon_local->flags.offlineLogstorageTimestamp = 1;
     daemon_local->flags.offlineLogstorageDelimiter = '_';
     daemon_local->flags.offlineLogstorageMaxCounter = UINT_MAX;


### PR DESCRIPTION
Fix the issue that DLT offline trace creating mutiple files
even after reaching MaxTrace size when filename is index based.

Related to: https://github.com/GENIVI/dlt-daemon/pull/174

Signed-off-by: Vo Trung Chi <chi.votrung@vn.bosch.com>