### PR TITLE
libdlt: add an interface to get the status of application registering

### DIFF
--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -245,7 +245,7 @@ typedef struct
 #   endif
     uint16_t log_buf_len;        /**< length of message buffer, by default: DLT_USER_BUF_MAX_SIZE */
 
-    uint32_t reference;
+    uint32_t app_reference;
 } DltUser;
 
 typedef int (*dlt_injection_callback_id)(uint32_t, void *, uint32_t, void *);
@@ -530,6 +530,13 @@ DltReturnValue dlt_register_app(const char *apid, const char *description);
  * @return Value from DltReturnValue enum
  */
 DltReturnValue dlt_unregister_app(void);
+
+/**
+ * Get the status of application registering.
+ *
+ * @return 1 means registered. 0 means not registered.
+ */
+int dlt_is_app_registered(void);
 
 /**
  * Unregister an application in the daemon and also flushes the buffered logs.

--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -244,6 +244,8 @@ typedef struct
     DltUserConnectionState connection_state;
 #   endif
     uint16_t log_buf_len;        /**< length of message buffer, by default: DLT_USER_BUF_MAX_SIZE */
+
+    uint32_t reference;
 } DltUser;
 
 typedef int (*dlt_injection_callback_id)(uint32_t, void *, uint32_t, void *);

--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -244,8 +244,6 @@ typedef struct
     DltUserConnectionState connection_state;
 #   endif
     uint16_t log_buf_len;        /**< length of message buffer, by default: DLT_USER_BUF_MAX_SIZE */
-
-    uint32_t app_reference;
 } DltUser;
 
 typedef int (*dlt_injection_callback_id)(uint32_t, void *, uint32_t, void *);

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -366,7 +366,6 @@ DltReturnValue dlt_init(void)
     dlt_user.dlt_is_file = 0;
     dlt_user.overflow = 0;
     dlt_user.overflow_counter = 0;
-    dlt_user.app_reference = 0;
 #ifdef DLT_SHM_ENABLE
     memset(&(dlt_user.dlt_shm), 0, sizeof(DltShm));
 
@@ -1002,8 +1001,6 @@ DltReturnValue dlt_register_app(const char *apid, const char *description)
         return DLT_RETURN_OK;
     }
 
-    dlt_user.app_reference++;
-
     DLT_SEM_LOCK();
 
     /* Store locally application id and application description */
@@ -1338,10 +1335,6 @@ DltReturnValue dlt_unregister_app(void)
     dlt_user.application_description = NULL;
 
     DLT_SEM_FREE();
-
-    if(dlt_user.app_reference > 0) {
-        dlt_user.app_reference--;
-    }
 
     return ret;
 }
@@ -4685,5 +4678,5 @@ DltReturnValue dlt_user_log_out_error_handling(void *ptr1, size_t len1, void *pt
 
 int dlt_is_app_registered(void)
 {
-    return (dlt_user.app_reference > 0) ? 1 : 0;
+    return (dlt_user.appID[0] == '\0') ? 0 : 1;
 }

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -366,6 +366,7 @@ DltReturnValue dlt_init(void)
     dlt_user.dlt_is_file = 0;
     dlt_user.overflow = 0;
     dlt_user.overflow_counter = 0;
+    dlt_user.reference = 0;
 #ifdef DLT_SHM_ENABLE
     memset(&(dlt_user.dlt_shm), 0, sizeof(DltShm));
 
@@ -1001,36 +1002,46 @@ DltReturnValue dlt_register_app(const char *apid, const char *description)
         return DLT_RETURN_OK;
     }
 
-    DLT_SEM_LOCK();
+    dlt_user.reference++;
 
-    /* Store locally application id and application description */
-    dlt_set_id(dlt_user.appID, apid);
+    if(dlt_user.reference <= 1) {
 
-    if (dlt_user.application_description != NULL)
-        free(dlt_user.application_description);
+        DLT_SEM_LOCK();
 
-    dlt_user.application_description = NULL;
+        /* Store locally application id and application description */
+        dlt_set_id(dlt_user.appID, apid);
 
-    if (description != NULL) {
-        size_t desc_len = strlen(description);
-        dlt_user.application_description = malloc(desc_len + 1);
+        if (dlt_user.application_description != NULL)
+            free(dlt_user.application_description);
 
-        if (dlt_user.application_description) {
-            strncpy(dlt_user.application_description, description, desc_len);
-            dlt_user.application_description[desc_len] = '\0';
+        dlt_user.application_description = NULL;
+
+        if (description != NULL) {
+            size_t desc_len = strlen(description);
+            dlt_user.application_description = malloc(desc_len + 1);
+
+            if (dlt_user.application_description) {
+                strncpy(dlt_user.application_description, description, desc_len);
+                dlt_user.application_description[desc_len] = '\0';
+            }
+            else {
+                DLT_SEM_FREE();
+                return DLT_RETURN_ERROR;
+            }
         }
-        else {
-            DLT_SEM_FREE();
-            return DLT_RETURN_ERROR;
-        }
+
+        DLT_SEM_FREE();
+
+        ret = dlt_user_log_send_register_application();
+
+        if ((ret == DLT_RETURN_OK) && (dlt_user.dlt_log_handle != -1))
+            ret = dlt_user_log_resend_buffer();
+
+        dlt_vlog(LOG_DEBUG, "%s done\n", __FUNCTION__);
     }
-
-    DLT_SEM_FREE();
-
-    ret = dlt_user_log_send_register_application();
-
-    if ((ret == DLT_RETURN_OK) && (dlt_user.dlt_log_handle != -1))
-        ret = dlt_user_log_resend_buffer();
+    else {
+        dlt_vlog(LOG_DEBUG, "%s ignored for reference=%d\n", __FUNCTION__, dlt_user.reference);
+    }
 
     return ret;
 }
@@ -1321,20 +1332,29 @@ DltReturnValue dlt_unregister_app(void)
         return DLT_RETURN_ERROR;
     }
 
-    /* Inform daemon to unregister application and all of its contexts */
-    ret = dlt_user_log_send_unregister_application();
+    if(dlt_user.reference <= 0) {
 
-    DLT_SEM_LOCK();
+        /* Inform daemon to unregister application and all of its contexts */
+        ret = dlt_user_log_send_unregister_application();
 
-    /* Clear and free local stored application information */
-    dlt_set_id(dlt_user.appID, "");
+        DLT_SEM_LOCK();
 
-    if (dlt_user.application_description != NULL)
-        free(dlt_user.application_description);
+        /* Clear and free local stored application information */
+        dlt_set_id(dlt_user.appID, "");
 
-    dlt_user.application_description = NULL;
+        if (dlt_user.application_description != NULL)
+            free(dlt_user.application_description);
 
-    DLT_SEM_FREE();
+        dlt_user.application_description = NULL;
+
+        DLT_SEM_FREE();
+
+        dlt_vlog(LOG_DEBUG, "%s done\n", __FUNCTION__);
+    }
+    else {
+        dlt_vlog(LOG_DEBUG, "%s ignored for reference=%d\n", __FUNCTION__, dlt_user.reference);
+        dlt_user.reference--;
+    }
 
     return ret;
 }

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1332,7 +1332,7 @@ DltReturnValue dlt_unregister_app(void)
         return DLT_RETURN_ERROR;
     }
 
-    if(dlt_user.reference <= 0) {
+    if(dlt_user.reference <= 1) {
 
         /* Inform daemon to unregister application and all of its contexts */
         ret = dlt_user_log_send_unregister_application();

--- a/tests/gtest_dlt_user.cpp
+++ b/tests/gtest_dlt_user.cpp
@@ -4464,6 +4464,14 @@ TEST(t_dlt_user_is_logLevel_enabled, nullpointer)
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_is_logLevel_enabled(NULL, DLT_LOG_FATAL));
 }
 
+TEST(t_dlt_is_app_registered, normal)
+{
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(1, dlt_is_app_registered());
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+    EXPECT_LE(0, dlt_is_app_registered());
+}
+
 /*/////////////////////////////////////// */
 /* main */
 int main(int argc, char **argv)

--- a/tests/gtest_dlt_user.cpp
+++ b/tests/gtest_dlt_user.cpp
@@ -4467,9 +4467,9 @@ TEST(t_dlt_user_is_logLevel_enabled, nullpointer)
 TEST(t_dlt_is_app_registered, normal)
 {
     EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
-    EXPECT_LE(1, dlt_is_app_registered());
+    EXPECT_EQ(1, dlt_is_app_registered());
     EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
-    EXPECT_LE(0, dlt_is_app_registered());
+    EXPECT_EQ(0, dlt_is_app_registered());
 }
 
 /*/////////////////////////////////////// */


### PR DESCRIPTION
I am developing a middleware with a single library. And I am using the dlt to output the logs.
But I find some of the executables that using my library was not using dlt, it means none will register the application, and my library could not output any logs.
But if I register the application in my library, my application id will override the application id of the executable who using dlt.

So, I did this change to make the register-application only work once.
If the excutable registered the application, my library 's registering will be ignored.
Only thing might change is, the executable need to register the application as soon as possible, early before any libraries.

Signed-off-by: Charles Chan <charles@zeerd.com>