### PR TITLE
Change DLT_CHECK_RCV_DATA_SIZE macro to an internal function

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -218,17 +218,6 @@ enum {
 #   define GET_LOG_INFO_LENGTH 13
 #   define SERVICE_OPT_LENGTH 3
 
-/* checks if received size is big enough for expected data */
-#   define DLT_CHECK_RCV_DATA_SIZE(received, required) \
-    ({ \
-        int _ret = DLT_RETURN_OK; \
-        if (((int)received - (int)required) < 0) { \
-            dlt_vlog(LOG_WARNING, "%s: Received data not complete\n", __func__); \
-            _ret = DLT_RETURN_ERROR; \
-        } \
-        _ret; \
-    })
-
 /**
  * Get the size of extra header parameters, depends on htyp.
  */
@@ -1249,6 +1238,13 @@ DltReturnValue dlt_set_storageheader(DltStorageHeader *storageheader, const char
  */
 DltReturnValue dlt_check_storageheader(DltStorageHeader *storageheader);
 
+/**
+ * Checks if received size is big enough for expected data
+ * @param received size
+ * @param required size
+ * @return negative value if required size is not sufficient
+ * */
+DltReturnValue dlt_check_rcv_data_size(int received, int required);
 
 /**
  * Initialise static ringbuffer with a size of size.

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -881,7 +881,7 @@ void dlt_daemon_control_get_log_info(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceGetLogInfoRequest)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceGetLogInfoRequest)) < 0)
         return;
 
     user_list = dlt_daemon_find_users_list(daemon, daemon->ecuid, verbose);
@@ -1740,7 +1740,7 @@ void dlt_daemon_control_set_log_level(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetLogLevel)) < 0)
         return;
 
     req = (DltServiceSetLogLevel *)(msg->databuffer);
@@ -1913,7 +1913,7 @@ void dlt_daemon_control_set_trace_status(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetLogLevel)) < 0)
         return;
 
     req = (DltServiceSetLogLevel *)(msg->databuffer);
@@ -2007,7 +2007,7 @@ void dlt_daemon_control_set_default_log_level(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
         return;
 
     req = (DltServiceSetDefaultLogLevel *)(msg->databuffer);
@@ -2047,7 +2047,7 @@ void dlt_daemon_control_set_all_log_level(int sock,
         return;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
         return;
 
     req = (DltServiceSetDefaultLogLevel *)(msg->databuffer);
@@ -2084,7 +2084,7 @@ void dlt_daemon_control_set_default_trace_status(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
         return;
 
     req = (DltServiceSetDefaultLogLevel *)(msg->databuffer);
@@ -2124,7 +2124,7 @@ void dlt_daemon_control_set_all_trace_status(int sock,
         return;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetDefaultLogLevel)) < 0)
         return;
 
     req = (DltServiceSetDefaultLogLevel *)(msg->databuffer);
@@ -2161,7 +2161,7 @@ void dlt_daemon_control_set_timing_packets(int sock,
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceSetVerboseMode)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetVerboseMode)) < 0)
         return;
 
     req = (DltServiceSetVerboseMode *)(msg->databuffer);
@@ -2429,7 +2429,7 @@ void dlt_daemon_control_service_logstorage(int sock,
         return;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceOfflineLogstorage)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceOfflineLogstorage)) < 0)
         return;
 
     req = (DltServiceOfflineLogstorage *)(msg->databuffer);
@@ -2610,7 +2610,7 @@ void dlt_daemon_control_passive_node_connect(int sock,
         return;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServicePassiveNodeConnect)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServicePassiveNodeConnect)) < 0)
         return;
 
     req = (DltServicePassiveNodeConnect *)msg->databuffer;

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -971,7 +971,7 @@ DLT_STATIC DltReturnValue dlt_gateway_parse_get_log_info(DltDaemon *daemon,
         return DLT_RETURN_WRONG_PARAMETER;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize, sizeof(DltServiceGetLogInfoResponse)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceGetLogInfoResponse)) < 0)
         return DLT_RETURN_ERROR;
 
     /* if the request was send from gateway, clear all application and context list */
@@ -1093,7 +1093,7 @@ DLT_STATIC int dlt_gateway_parse_get_default_log_level(DltDaemon *daemon,
         return DLT_RETURN_WRONG_PARAMETER;
     }
 
-    if (DLT_CHECK_RCV_DATA_SIZE(msg->datasize,
+    if (dlt_check_rcv_data_size(msg->datasize,
                                 sizeof(DltServiceGetDefaultLogLevelResponse)) < 0) {
         dlt_log(LOG_ERR, "Received data incomplete.\n");
         return DLT_RETURN_ERROR;

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -2110,6 +2110,16 @@ DltReturnValue dlt_set_storageheader(DltStorageHeader *storageheader, const char
     return DLT_RETURN_OK;
 }
 
+DltReturnValue dlt_check_rcv_data_size(int received, int required)
+{
+    int _ret = DLT_RETURN_OK;
+    if ((received - required) < 0) {
+        dlt_vlog(LOG_WARNING, "%s: Received data not complete\n", __func__);
+        _ret = DLT_RETURN_ERROR;
+    }
+    return _ret;
+}
+
 DltReturnValue dlt_check_storageheader(DltStorageHeader *storageheader)
 {
     if (storageheader == NULL)


### PR DESCRIPTION
fixes #190

Changing the `DLT_CHECK_RCV_DATA_SIZE` macro into a static inline function requires to include `syslog.h` (due to the use of `LOG_WARNING`) and to declare `dlt_vlog()` earlier. Therefore, I think it's acutally best to just change this macro into an internal function. 