### PR TITLE
BugFix: SEGFAULT when using AppArmor

### DIFF
--- a/include/dlt/dlt_offline_trace.h
+++ b/include/dlt/dlt_offline_trace.h
@@ -128,7 +128,7 @@ extern DltReturnValue dlt_offline_trace_write(DltOfflineTrace *trace,
  * Get size of currently used offline trace buffer
  * @return size in bytes
  */
-extern unsigned long dlt_offline_trace_get_total_size(DltOfflineTrace *trace);
+extern ssize_t dlt_offline_trace_get_total_size(DltOfflineTrace *trace);
 
 /**
  * Provides info about the offline logs storage directory


### PR DESCRIPTION
* Symptome: If access to the trace directory is not
  granted by AppArmor access(...) still reports otherwise.
  dlt_offline_trace_get_total_size(...)
  tries to open the dir via opendir(...) and tries a
  readdir without any further check, which results in an
  SEGFAULT

* Solution: (1) Make dlt_offline_trace_get_total_size return
  ssize_t instead of unsigned long, which gives us a
  chance to return an error state (2) Check the return value
  from opendir(...) and bail out on error. Use this to return
  DLT_RETURN_ERROR in dlt_offline_trace_check_size.

* ToDo: (1) Error state is not yet checked and reported
  back. On Error we just don't generate any offline
  log files without any further complain. (2) Find a replacement
  for access(...) which reports properly under AppArmor.
  (3) Reoprt the confusing behaviour of access(...) to the
  AppArmor team.

Signed-off-by: Sebastian Kloska <seebastian.kloska@snafu.de>