### PR TITLE
dlt.conf: suppress the warnings udp multicast

### DIFF
--- a/src/daemon/dlt.conf
+++ b/src/daemon/dlt.conf
@@ -188,13 +188,13 @@ ControlSocketPath = /tmp/dlt-ctrl.sock
 # UDP Multicast Configuration                                                #
 ##############################################################################
 # Enable UDP connection support for daemon(Control Message/Multicast is enabled)
-UDPConnectionSetup = 1
+# UDPConnectionSetup = 1
 
 # UDP multicast address(default:225.0.0.37)
-UDPMulticastIPAddress = 225.0.0.37
+# UDPMulticastIPAddress = 225.0.0.37
 
 # UDP multicast port(default:3491)
-UDPMulticastIPPort = 3491
+# UDPMulticastIPPort = 3491
 
 ##############################################################################
 # BindAddress Limitation                                                     #


### PR DESCRIPTION
There are some warnings while running dlt-daemon:

$dlt-daemon
Unknown option: UDPConnectionSetup=1
Unknown option: UDPMulticastIPAddress=225.0.0.37
Unknown option: UDPMulticastIPPort=3491

cause the WITH_UDP_CONNECTION is not enabled by default (c9d1ba4b).
The configuration for this feature should be sync.

Signed-off-by: Phong Tran <tranmanphong@gmail.com>