### PR TITLE
doc/dlt_for_developers.md: Fix wrong include directive

### DIFF
--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -27,7 +27,7 @@ minimal code example. Detailed information about the API can be found later in
 this document.
 
 ```
-#include <dlt/dlt.h>
+#include <dlt.h>
 
 DLT_DECLARE_CONTEXT(ctx); /* declare context */
 


### PR DESCRIPTION
Fixes the problem that users are not able to use DLT with the include directive `#include <dlt/dlt.h>` that is stated in the developer guide (see `doc/dlt_for_developers.md`).

This is required in order to build other GENIVI projects like (vsomeip, capicxx-core-runtime, ...) without any problems since they all seem to use the include directive mentioned above.

