### PR TITLE
Offline Logstorage: allow both LogAppName and ContextName to be ".*"

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -473,6 +473,29 @@ DLT_STATIC int dlt_logstorage_get_keys_list(char *ids, char *sep, char **list,
 }
 
 /**
+ * dlt_logstorage_create_keys_any
+ *
+ * Prepares keys without app ID and context ID, will use ecuid if provided
+ * (ecuid\:\:) or (\:\:)
+ *
+ * @param ecuid          ECU ID
+ * @param ctid           Context ID
+ * @param key            Prepared key stored here
+ * @return               None
+ */
+DLT_STATIC void dlt_logstorage_create_keys_any(char *ecuid, char *ctid,
+                                                     char *key)
+{
+    if (ecuid != NULL) {
+        strncpy(key, ecuid, strlen(ecuid));
+        strncat(key, "::", 2);
+    }
+    else {
+        strncpy(key, "::", 2);
+    }
+}
+
+/**
  * dlt_logstorage_create_keys_only_ctid
  *
  * Prepares keys with context ID alone, will use ecuid if provided
@@ -687,7 +710,9 @@ DLT_STATIC int dlt_logstorage_create_keys(char *apids,
         for (j = 0; j < num_ctids; j++) {
             curr_ctid = ctid_list + (j * (DLT_ID_SIZE + 1));
 
-            if (strncmp(curr_apid, ".*", 2) == 0) /* only context id matters */
+            if (strncmp(curr_apid, ".*", 2) == 0 && strncmp(curr_ctid, ".*", 2) == 0) /* app id and context id does not matter */
+                dlt_logstorage_create_keys_any(ecuid, curr_ctid, curr_key);
+            else if (strncmp(curr_apid, ".*", 2) == 0) /* only context id matters */
                 dlt_logstorage_create_keys_only_ctid(ecuid, curr_ctid, curr_key);
             else if (strncmp(curr_ctid, ".*", 2) == 0) /* only app id matters*/
                 dlt_logstorage_create_keys_only_apid(ecuid, curr_apid, curr_key);


### PR DESCRIPTION
In [Offline Logstorage documentation](https://github.com/GENIVI/dlt-daemon/blob/master/doc/dlt_offline_logstorage.md) it is stated that `LogAppName` and `ContextName` may be set to `.*` to match against any value.

However, if both options are set to `.*`, the wildcard is applied only to application ID.
I think this is a mistake (the documentation does not specify that the wildcard cannot be applied to both fields simultaneously). This patch allows to specify both fields as wildcard.

Test configuration:
```
root@mx8:/media/log# cat dlt_logstorage.conf 
[FILTER1]
LogAppName=.*
ContextName=.*
LogLevel=DLT_LOG_DEBUG
File=ECU2
FileSize=102400
NOFiles=10
EcuID=ECU2
```
