### PR TITLE
common: Fix uint64 type

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -3506,7 +3506,7 @@ DltReturnValue dlt_message_argument_print(DltMessage *msg,
     #if defined (__WIN32__) && !defined(_MSC_VER)
                 snprintf(text, textlength, "%I64u", value64u);
     #else
-                snprintf(text, textlength, "%" PRId64, value64u);
+                snprintf(text, textlength, "%" PRIu64, value64u);
     #endif
             }
 


### PR DESCRIPTION
The log message was printed as a signed value for uint64 type. This
commit fixes to print as an unsigned value.

Signed-off-by: Saya Sugiura <ssugiura@jp.adit-jv.com>