### PR TITLE
Add sized string functions

### DIFF
--- a/include/dlt/dlt_user.h
+++ b/include/dlt/dlt_user.h
@@ -382,6 +382,17 @@ DltReturnValue dlt_user_log_write_int64(DltContextData *log, int64_t data);
 DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text);
 
 /**
+ * Write a potentially non-null-terminated ASCII string into a DLT log message.
+ * dlt_user_log_write_start has to be called before adding any attributes to the log message.
+ * Finish sending log message by calling dlt_user_log_write_finish.
+ * @param log pointer to an object containing information about logging context data
+ * @param text pointer to the parameter written into log message
+ * @param length length in bytes of @a text (without any termination character)
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_write_sized_string(DltContextData *log, const char *text, uint16_t length);
+
+/**
  * Write a constant null terminated ASCII string into a DLT log message.
  * In non verbose mode DLT parameter will not be send at all.
  * dlt_user_log_write_start has to be called before adding any attributes to the log message.
@@ -393,6 +404,18 @@ DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text);
 DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const char *text);
 
 /**
+ * Write a constant, potentially non-null-terminated ASCII string into a DLT log message.
+ * In non verbose mode DLT parameter will not be send at all.
+ * dlt_user_log_write_start has to be called before adding any attributes to the log message.
+ * Finish sending log message by calling dlt_user_log_write_finish.
+ * @param log pointer to an object containing information about logging context data
+ * @param text pointer to the parameter written into log message containing null termination.
+ * @param length length in bytes of @a text (without any termination character)
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_write_sized_constant_string(DltContextData *log, const char *text, uint16_t length);
+
+/**
  * Write a null terminated UTF8 string into a DLT log message.
  * dlt_user_log_write_start has to be called before adding any attributes to the log message.
  * Finish sending log message by calling dlt_user_log_write_finish.
@@ -401,6 +424,17 @@ DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const cha
  * @return Value from DltReturnValue enum
  */
 DltReturnValue dlt_user_log_write_utf8_string(DltContextData *log, const char *text);
+
+/**
+ * Write a potentially non-null-terminated UTF8 string into a DLT log message.
+ * dlt_user_log_write_start has to be called before adding any attributes to the log message.
+ * Finish sending log message by calling dlt_user_log_write_finish.
+ * @param log pointer to an object containing information about logging context data
+ * @param text pointer to the parameter written into log message
+ * @param length length in bytes of @a text (without any termination character)
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_write_sized_utf8_string(DltContextData *log, const char *text, uint16_t length);
 
 /**
  * Write a binary memory block into a DLT log message.

--- a/include/dlt/dlt_user_macros.h
+++ b/include/dlt/dlt_user_macros.h
@@ -322,6 +322,17 @@
     (void)dlt_user_log_write_string(&log_local, TEXT)
 
 /**
+ * Add string parameter with given length to the log messsage.
+ * The string in @a TEXT does not need to be null-terminated, but
+ * the copied string will be null-terminated at its destination
+ * in the message buffer.
+ * @param TEXT ASCII string
+ * @param LEN length in bytes to take from @a TEXT
+ */
+#define DLT_SIZED_STRING(TEXT, LEN) \
+    (void)dlt_user_log_write_sized_string(&log_local, TEXT, LEN)
+
+/**
  * Add constant string parameter to the log messsage.
  * @param TEXT Constant ASCII string
  */
@@ -329,11 +340,33 @@
     (void)dlt_user_log_write_constant_string(&log_local, TEXT)
 
 /**
+ * Add constant string parameter with given length to the log messsage.
+ * The string in @a TEXT does not need to be null-terminated, but
+ * the copied string will be null-terminated at its destination
+ * in the message buffer.
+ * @param TEXT Constant ASCII string
+ * @param LEN length in bytes to take from @a TEXT
+ */
+#define DLT_SIZED_CSTRING(TEXT, LEN) \
+    (void)dlt_user_log_write_sized_constant_string(&log_local, TEXT, LEN)
+
+/**
  * Add utf8-encoded string parameter to the log messsage.
  * @param TEXT UTF8-encoded string
  */
 #define DLT_UTF8(TEXT) \
     (void)dlt_user_log_write_utf8_string(&log_local, TEXT)
+
+/**
+ * Add utf8-encoded string parameter with given length to the log messsage.
+ * The string in @a TEXT does not need to be null-terminated, but
+ * the copied string will be null-terminated at its destination
+ * in the message buffer.
+ * @param TEXT UTF8-encoded string
+ * @param LEN length in bytes to take from @a TEXT
+ */
+#define DLT_SIZED_UTF8(TEXT, LEN) \
+    (void)dlt_user_log_write_sized_utf8_string(&log_local, TEXT, LEN)
 
 /**
  * Add boolean parameter to the log messsage.

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -2333,15 +2333,31 @@ DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text)
     return dlt_user_log_write_string_utils(log, text, ASCII_STRING);
 }
 
+DltReturnValue dlt_user_log_write_sized_string(DltContextData *log, const char *text, uint16_t length)
+{
+    return dlt_user_log_write_sized_string_utils(log, text, length, ASCII_STRING);
+}
+
 DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const char *text)
 {
     /* Send parameter only in verbose mode */
     return dlt_user.verbose_mode ? dlt_user_log_write_string(log, text) : DLT_RETURN_OK;
 }
 
+DltReturnValue dlt_user_log_write_sized_constant_string(DltContextData *log, const char *text, uint16_t length)
+{
+    /* Send parameter only in verbose mode */
+    return dlt_user.verbose_mode ? dlt_user_log_write_sized_string(log, text, length) : DLT_RETURN_OK;
+}
+
 DltReturnValue dlt_user_log_write_utf8_string(DltContextData *log, const char *text)
 {
     return dlt_user_log_write_string_utils(log, text, UTF8_STRING);
+}
+
+DltReturnValue dlt_user_log_write_sized_utf8_string(DltContextData *log, const char *text, uint16_t length)
+{
+    return dlt_user_log_write_sized_string_utils(log, text, length, UTF8_STRING);
 }
 
 DltReturnValue dlt_user_log_write_sized_string_utils(DltContextData *log, const char *text, uint16_t length, const enum StringType type)

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -95,7 +95,7 @@ static int atexit_registered = 0;
 /* used to disallow DLT usage in fork() child */
 static int g_dlt_is_child = 0;
 /* String truncate message */
-static const char *STR_TRUNCATED_MESSAGE = "... <<Message truncated, too long>>";
+static const char STR_TRUNCATED_MESSAGE[] = "... <<Message truncated, too long>>";
 
 /* Enum for type of string */
 enum StringType

--- a/tests/gtest_dlt_user.cpp
+++ b/tests/gtest_dlt_user.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest.h"
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
 extern "C" {
 #include "dlt_user.h"
@@ -62,8 +63,11 @@ extern "C" {
  * int dlt_user_log_write_int32(DltContextData *log, int32_t data);
  * int dlt_user_log_write_int64(DltContextData *log, int64_t data);
  * int dlt_user_log_write_string( DltContextData *log, const char *text);
+ * int dlt_user_log_write_sized_string(DltContextData *log, const char *text, uint16_t length);
  * int dlt_user_log_write_constant_string( DltContextData *log, const char *text);
+ * int dlt_user_log_write_sized_constant_string(DltContextData *log, const char *text, uint16_t length);
  * int dlt_user_log_write_utf8_string(DltContextData *log, const char *text);
+ * int dlt_user_log_write_sized_utf8_string(DltContextData *log, const char *text, uint16_t length);
  * int dlt_user_log_write_raw(DltContextData *log,void *data,uint16_t length);
  * int dlt_user_log_write_raw_formatted(DltContextData *log,void *data,uint16_t length,DltFormatType type);
  */
@@ -1875,6 +1879,31 @@ TEST(t_dlt_user_log_write_string, nullpointer)
 }
 
 /*/////////////////////////////////////// */
+/* t_dlt_user_log_write_sized_string */
+
+TEST(t_dlt_user_log_write_sized_string, normal)
+{
+    DltContext context;
+    DltContextData contextData;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_register_context(&context, "TEST", "dlt_user.c t_dlt_user_log_write_sized_string normal"));
+
+    /* normal values */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEFAULT));
+    const char text1[] = "TheQuickBrownFox";
+    const char *arg1_start = strchr(text1, 'Q');
+    const size_t arg1_len = 5;
+    /* from the above string, send only the substring "Quick" */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_sized_string(&contextData, arg1_start, arg1_len));
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+}
+
+/*/////////////////////////////////////// */
 /* t_dlt_user_log_write_constant_string */
 TEST(t_dlt_user_log_write_constant_string, normal)
 {
@@ -2009,6 +2038,31 @@ TEST(t_dlt_user_log_write_constant_string, nullpointer)
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_constant_string(NULL, text1));
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_constant_string(NULL, NULL));
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_constant_string(&contextData, NULL));
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+}
+
+/*/////////////////////////////////////// */
+/* t_dlt_user_log_write_sized_constant_string */
+
+TEST(t_dlt_user_log_write_sized_constant_string, normal)
+{
+    DltContext context;
+    DltContextData contextData;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_register_context(&context, "TEST", "dlt_user.c t_dlt_user_log_write_sized_constant_string normal"));
+
+    /* normal values */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEFAULT));
+    const char text1[] = "TheQuickBrownFox";
+    const char *arg1_start = strchr(text1, 'Q');
+    const size_t arg1_len = 5;
+    /* from the above string, send only the substring "Quick" */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_sized_constant_string(&contextData, arg1_start, arg1_len));
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
 
     EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
@@ -2967,6 +3021,52 @@ TEST(t_dlt_user_log_write_utf8_string, nullpointer)
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_utf8_string(NULL, text1));
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_utf8_string(NULL, NULL));
     EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_utf8_string(&contextData, NULL));
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+}
+
+/*/////////////////////////////////////// */
+/* t_dlt_user_log_write_sized_utf8_string */
+
+TEST(t_dlt_user_log_write_sized_utf8_string, partial_string)
+{
+    DltContext context;
+    DltContextData contextData;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_register_context(&context, "TEST", "dlt_user.c t_dlt_user_log_write_sized_utf8_string normal"));
+
+    /* normal values */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEFAULT));
+    const char text1[] = "TheQuickBrownFox";
+    const char* arg1_start = strchr(text1, 'Q');
+    const size_t arg1_len = 5;
+    /* from the above string, send only the substring "Quick" */
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_sized_utf8_string(&contextData, arg1_start, arg1_len));
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
+    EXPECT_LE(DLT_RETURN_OK, dlt_unregister_app());
+}
+
+TEST(t_dlt_user_log_write_sized_utf8_string, nullpointer)
+{
+    DltContext context;
+    DltContextData contextData;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_register_app("TUSR", "dlt_user.c tests"));
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_register_context(&context, "TEST", "dlt_user.c t_dlt_user_log_write_sized_utf8_string nullpointer"));
+
+    /* NULL */
+    const char *text1 = "test1";
+    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEFAULT));
+    EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_sized_utf8_string(NULL, text1, 5));
+    EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_sized_utf8_string(NULL, NULL, 5));
+    EXPECT_GE(DLT_RETURN_ERROR, dlt_user_log_write_sized_utf8_string(&contextData, NULL, 5));
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
 
     EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));


### PR DESCRIPTION
This use case is common in C++ code nowadays, due to the usage of e.g.
std::string_view, which does not provide a function for retrieving a
null-terminated C-string, but which provides quick access to the string
length via std::string_view::size().

Such use cases can now avoid an entirely unnecessary strlen() call.