### PR TITLE
Fixed internal empty message

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1772,9 +1772,11 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
                                                 daemon_local->flags.vflag);
     }
 
-    dlt_vlog(LOG_DEBUG,
+    snprintf(local_str,
+             DLT_DAEMON_TEXTBUFSIZE,
              "New client connection #%d established, Total Clients : %d\n",
              in_sock, daemon_local->client_connections);
+    dlt_log(LOG_DEBUG, local_str);
     dlt_daemon_log_internal(daemon, daemon_local, local_str, daemon_local->flags.vflag);
 
     if (daemon_local->client_connections == 1) {


### PR DESCRIPTION
On a new client connection, `dlt_daemon_log_internal` is called with with a null `local_str`.
There are no side effects, apart empty lines in DLT viewer.

The mistake was introduced in a refactoring. I have reverted those lines to the [previous version](https://github.com/GENIVI/dlt-daemon/commit/bfa7026b355db32d91374997cc86b56fedc3e861#diff-11985d537fb773028c45cf71c649f660L1662).
