### PR TITLE
Update gtest_dlt_all.sh to detect core dump

### DIFF
--- a/.travis/gtest_dlt_all.sh
+++ b/.travis/gtest_dlt_all.sh
@@ -28,14 +28,21 @@ function gtest_run_test()
 {
     LOG="../.travis/$1.log"
 
+    # Send all messsages and system errors to log file
+    export LIBC_FATAL_STDERR_=1
+
     # Execute unit test
-    ./$1 > $LOG
+    { ./$1 ;} > $LOG 2>&1
+
+    # Release
+    export LIBC_FATAL_STDERR_=0
 
     # Check for result
-    grep "FAILED TEST" $LOG
+    grep "FAILED TEST\|core dumped" $LOG
     if [ $? -eq 0 ]
     then
         cat $LOG
+        echo "$1 failed"
         exit 1
     fi
     echo "$1 passed"


### PR DESCRIPTION
Currently the gtest_dlt_all.sh script bypass any core dumped errors if it exists. This change helps TravisCI to detect that error.