### PR TITLE
dlt_user.c: fix the lack of DLT_NETWORK_TRACE_ENABLE definition

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -4631,12 +4631,14 @@ int dlt_start_threads()
         return -1;
     }
 
+#ifdef DLT_NETWORK_TRACE_ENABLE
     /* Start the segmented thread */
     if (pthread_create(&(dlt_user.dlt_segmented_nwt_handle), NULL,
                        (void *)dlt_user_trace_network_segmented_thread, NULL)) {
         dlt_log(LOG_CRIT, "Can't start segmented thread!\n");
         return -1;
     }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
To totally solve the issue [237](https://github.com/GENIVI/dlt-daemon/issues/237), the DLT_NETWORK_TRACE_ENABLE should be added before starting the segmented thread.

The cause of lacking this definition could be due to my mistake when updating minor version 2.18.4 to 2.18.5

Signed-off-by: KHANH LUONG HONG DUY <khanh.luonghongduy@vn.bosch.com>