### PR TITLE
sd-daemon.c: Fix build with newer glibc and musl libc

### DIFF
--- a/systemd/3rdparty/sd-daemon.c
+++ b/systemd/3rdparty/sd-daemon.c
@@ -35,7 +35,7 @@
 #ifdef __BIONIC__
 #include <linux/fcntl.h>
 #else
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #endif
 #include <netinet/in.h>
 #include <stdlib.h>


### PR DESCRIPTION
Reported by Khem Raj on meta-oe list

TOPDIR/build/tmp/work/armv7vet2hf-neon-yoe-linux-musleabi/dlt-daemon/2.18.5-r0/recipe-sysroot/usr/include/sys/fcntl.h:1:2: error: redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror,-W#warnings]
 ^
1 error generated.

Signed-off-by: Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
Signed-off-by: Gianfranco Costamagna <locutusofborg@debian.org>