### PR TITLE
Modify CMAKE_C_COMPILER check for QNX to accept "qcc"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(WITH_DLT_USE_IPv6)
     add_definitions(-DDLT_USE_IPv6)
 endif()
 
-if(WITH_DLT_QNX_SYSTEM AND NOT "${CMAKE_C_COMPILER}" MATCHES "nto-qnx")
+if(WITH_DLT_QNX_SYSTEM AND NOT "${CMAKE_C_COMPILER}" MATCHES "nto-qnx|qcc")
     message(FATAL_ERROR "Can only compile for QNX with a QNX compiler.")
 endif()
 


### PR DESCRIPTION
nto-qnx matches architecture "sub-binaries" for qcc, but can also invoke with qcc binary and specify architecture. The CMake documentation has an example for a QNX toolchain file that sets CMAKE_C_COMPILER to qcc, so it is probably very common. See:

https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-qnx

Not sure why this check is needed. (Is qcc really the only compiler that can be used to build for QNX?) An alternative could be to remove it completely.