### PR TITLE
Fix valgrind memory issue

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -87,6 +87,12 @@
 #      include <time.h>
 #   endif
 
+#   if defined(__GNUC__)
+#      define PURE_FUNCTION __attribute__((pure))
+#   else
+#      define PURE_FUNCTION /* nothing */
+#   endif
+
 #   if !defined (__WIN32__) && !defined(_MSC_VER)
 #      include <termios.h>
 #   endif
@@ -859,6 +865,17 @@ DltReturnValue dlt_print_mixed_string(char *text, int textlength, uint8_t *ptr, 
  * @return negative value if there was an error
  */
 DltReturnValue dlt_print_char_string(char **text, int textlength, uint8_t *ptr, int size);
+
+/**
+ * Helper function to determine a bounded length of a string.
+ * This function returns zero if @a str is a null pointer,
+ * and it returns @a maxsize if the null character was not found in the first @a maxsize bytes of @a str.
+ * This is a re-implementation of C11's strnlen_s, which we cannot yet assume to be available.
+ * @param text pointer to string whose length is to be determined
+ * @param maxsize maximal considered length of @a str
+ * @return the bounded length of the string
+ */
+PURE_FUNCTION size_t dlt_strnlen_s(const char* str, size_t maxsize);
 
 /**
  * Helper function to print an id.

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -286,25 +286,32 @@ DltReturnValue dlt_print_char_string(char **text, int textlength, uint8_t *ptr, 
     return DLT_RETURN_OK;
 }
 
+size_t dlt_strnlen_s(const char* str, size_t maxsize)
+{
+    if (str == NULL)
+        return 0;
+
+    for (size_t i = 0; i < maxsize; ++i) {
+        if (str[i] == '\0')
+            return i;
+    }
+    return maxsize;
+}
+
 void dlt_print_id(char *text, const char *id)
 {
     /* check nullpointer */
     if ((text == NULL) || (id == NULL))
         return;
 
-    int i, len;
-
     /* Initialize text */
-    for (i = 0; i < DLT_ID_SIZE; i++)
-        text[i] = '-';
+    memset(text, '-', DLT_ID_SIZE);
 
     text[DLT_ID_SIZE] = 0;
 
-    len = ((strlen(id) <= DLT_ID_SIZE) ? strlen(id) : DLT_ID_SIZE);
+    size_t len = dlt_strnlen_s(id, DLT_ID_SIZE);
 
-    /* Check id*/
-    for (i = 0; i < len; i++)
-        text[i] = id[i];
+    memcpy(text, id, len);
 }
 
 void dlt_set_id(char *id, const char *text)

--- a/tests/gtest_dlt_common.cpp
+++ b/tests/gtest_dlt_common.cpp
@@ -4067,6 +4067,49 @@ TEST(t_dlt_print_char_string, nullpointer)
 
 
 
+/* Begin Method:dlt_common::dlt_strnlen_s*/
+TEST(t_dlt_strnlen_s, nullpointer)
+{
+    size_t len = dlt_strnlen_s(NULL, 0);
+    EXPECT_EQ(len, 0);
+}
+
+TEST(t_dlt_strnlen_s, len_zero)
+{
+    const char text[] = "The Quick Brown Fox";
+
+    size_t len = dlt_strnlen_s(text, 0);
+    EXPECT_EQ(len, 0);
+}
+
+TEST(t_dlt_strnlen_s, len_smaller)
+{
+    const char text[] = "The Quick Brown Fox";
+
+    size_t len = dlt_strnlen_s(text, 10);
+    EXPECT_EQ(len, 10);
+}
+
+TEST(t_dlt_strnlen_s, len_equal)
+{
+    const char text[] = "The Quick Brown Fox";
+
+    size_t len = dlt_strnlen_s(text, 19);
+    EXPECT_EQ(len, 19);
+}
+
+TEST(t_dlt_strnlen_s, len_larger)
+{
+    const char text[] = "The Quick Brown Fox";
+
+    size_t len = dlt_strnlen_s(text, 100);
+    EXPECT_EQ(len, 19);
+}
+/* End Method:dlt_common::dlt_strnlen_s*/
+
+
+
+
 /* Begin Method:dlt_common::dlt_print_id */
 TEST(t_dlt_print_id, normal)
 {


### PR DESCRIPTION
This changeset fixes a memory access error reported by valgrind:

==21924== Conditional jump or move depends on uninitialised value(s)
==21924==    at 0x4C30F78: strlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21924==    by 0x4E4B5A0: dlt_print_id (dlt_common.c:303)
==21924==    by 0x4E4CF47: dlt_message_header_flags (dlt_common.c:687)
==21924==    by 0x4E51434: dlt_message_print_ascii (dlt_common.c:3169)
==21924==    by 0x4E4247A: dlt_user_print_msg (dlt_user.c:4108)
==21924==    by 0x4E46D92: dlt_user_log_send_log (dlt_user.c:3670)
==21924==    by 0x4E46F14: dlt_user_log_write_finish (dlt_user.c:1611)
