### PR TITLE
Make it easier to use libdlt when building DLT as a CMake subproject

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
 endif()
 
 target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_include_directories(dlt PUBLIC ${PROJECT_SOURCE_DIR}/include/dlt ${PROJECT_BINARY_DIR}/include/dlt)
 set_target_properties(dlt PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 install(TARGETS dlt


### PR DESCRIPTION
By calling `target_include_directories()` for the `dlt` target in `src/lib/`. CMake filters out duplicate include paths. So even if the include directories are already added with `include_directories()` in the top-level `CMakeLists.txt`, they are not duplicated when the compiler is invoked.

For example, with this patch, the following works:

```bash
[~/Source/foo]$ ls
bar  CMakeLists.txt  dlt-daemon
[~/Source/foo]$ cat CMakeLists.txt
cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
project(foo)

add_subdirectory(dlt-daemon)
add_subdirectory(bar)
[~/Source/foo]$ cat bar/CMakeLists.txt
cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
project(bar)

add_executable(bar main.cpp)
target_link_libraries(bar dlt)
install(TARGETS bar RUNTIME DESTINATION bin)
```

`bar/main.cpp` contains the example from the top of `doc/dlt_for_developers.md` that does `"#include <dlt.h>"` and then uses the DLT logging macros.