### PR TITLE
dlt-daemon.c: exit early on error

### DIFF
--- a/src/daemon/dlt_daemon_socket.c
+++ b/src/daemon/dlt_daemon_socket.c
@@ -66,14 +66,16 @@ int dlt_daemon_socket_open(int *sock, unsigned int servPort, char *ip)
     /* create socket */
     if ((*sock = socket(AF_INET6, SOCK_STREAM, 0)) == -1) {
         lastErrno = errno;
-        dlt_vlog(LOG_WARNING, "dlt_daemon_socket_open: socket() error %d: %s\n", lastErrno, strerror(lastErrno));
+        dlt_vlog(LOG_ERR, "dlt_daemon_socket_open: socket() error %d: %s\n", lastErrno, strerror(lastErrno));
+        return -1;
     }
 
 #else
 
     if ((*sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         lastErrno = errno;
-        dlt_vlog(LOG_WARNING, "dlt_daemon_socket_open: socket() error %d: %s\n", lastErrno, strerror(lastErrno));
+        dlt_vlog(LOG_ERR, "dlt_daemon_socket_open: socket() error %d: %s\n", lastErrno, strerror(lastErrno));
+        return -1;
     }
 
 #endif
@@ -83,10 +85,11 @@ int dlt_daemon_socket_open(int *sock, unsigned int servPort, char *ip)
     /* setsockpt SO_REUSEADDR */
     if (setsockopt(*sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
         lastErrno = errno;
-        dlt_vlog(LOG_WARNING,
+        dlt_vlog(LOG_ERR,
                  "dlt_daemon_socket_open: Setsockopt error %d in dlt_daemon_local_connection_init: %s\n",
                  lastErrno,
                  strerror(lastErrno));
+        return -1;
     }
 
     /* bind */


### PR DESCRIPTION
Change warning to error, as it will abort the daemon startup.
Also reduce the amount of follow up error messages. 

Signed-off-by: Moritz Warning <moritzwarning@web.de>