### PR TITLE
Remove nonexistent file from Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -82,7 +82,6 @@ cc_binary {
         "src/daemon/dlt_daemon_common.c",
         "src/daemon/dlt_daemon_connection.c",
         "src/daemon/dlt_daemon_event_handler.c",
-        "src/daemon/dlt_daemon_filter.c",
         "src/daemon/dlt_daemon_offline_logstorage.c",
         "src/daemon/dlt_daemon_serial.c",
         "src/daemon/dlt_daemon_socket.c",


### PR DESCRIPTION
Can not see `src/daemon/dlt_daemon_filter.c` in history. Not sure where it comes from. Internal branch used by submitter of initial Android.bp?