### PR TITLE
dlt-daemon: Adds an option to disable injection mode

### DIFF
--- a/doc/dlt.conf.5.md
+++ b/doc/dlt.conf.5.md
@@ -120,6 +120,12 @@ Initial trace-status that is sent when an application registers. DLT_TRACE_STATU
 Force log level and trace status of contexts to not exceed "ContextLogLevel" and "ContextTraceStatus". If set to 1 (ON) whenever a context registers or changes the log-level it has to be lower or equal to ContextLogLevel.
 
     Default: 0
+    
+## InjectionMode
+
+If set to 0, the injection mode (see [here](./dlt_for_developers.md#DLT-Injection-Messages)) is disabled.
+
+    Default: 1
 
 # GATEWAY CONFIGURATION
 

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -301,6 +301,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     daemon_local->UDPMulticastIPPort = MULTICASTIPPORT;
 #endif
     daemon_local->flags.ipNodes = NULL;
+    daemon_local->flags.injectionMode = 1;
 
     /* open configuration file */
     if (daemon_local->flags.cvalue[0])
@@ -683,6 +684,9 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                         else {
                             dlt_vlog(LOG_WARNING, "BindAddress option is empty\n");
                         }
+                    }
+                    else if (strcmp(token, "InjectionMode") == 0) {
+                        daemon_local->flags.injectionMode = atoi(value);
                     }
                     else {
                         fprintf(stderr, "Unknown option: %s=%s\n", token, value);

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -135,7 +135,8 @@ typedef struct
     int contextLogLevel;  /**< (int) log level sent to context if registered with default log-level or if enforced*/
     int contextTraceStatus;   /**< (int) trace status sent to context if registered with default trace status  or if enforced*/
     int enforceContextLLAndTS;  /**< (Boolean) Enforce log-level, trace-status not to exceed contextLogLevel, contextTraceStatus */
-    DltBindAddress_t *ipNodes; /**< (String: BindAddress) The daemon accepts connections only on this list of IP addresses */
+    DltBindAddress_t* ipNodes; /**< (String: BindAddress) The daemon accepts connections only on this list of IP addresses */
+    int injectionMode;  /**< (Boolean) Injection mode */
 } DltDaemonFlags;
 /**
  * The global parameters of a dlt daemon.

--- a/src/daemon/dlt.conf
+++ b/src/daemon/dlt.conf
@@ -72,6 +72,9 @@ RingbufferStepSize = 500000
 # If set to 1 (ON) whenever a context registers or changes the log-level it has to be lower or equal to ContextLogLevel
 # ForceContextLogLevelAndTraceStatus = 1
 
+# Allows injection mode usage (Default: 1)
+# InjectionMode = 1
+
 ########################################################################
 # Gateway Configuration                                                #
 ########################################################################

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1550,7 +1550,7 @@ void dlt_daemon_control_callsw_cinjection(int sock,
 
     PRINT_FUNCTION_VERBOSE(verbose);
 
-    if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
+    if ((daemon == NULL) || (daemon_local == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
     datalength = msg->datasize;
@@ -1558,6 +1558,12 @@ void dlt_daemon_control_callsw_cinjection(int sock,
 
     DLT_MSG_READ_VALUE(id_tmp, ptr, datalength, uint32_t); /* Get service id */
     id = DLT_ENDIAN_GET_32(msg->standardheader->htyp, id_tmp);
+
+    /* injectionMode is disabled */
+    if (daemon_local->flags.injectionMode == 0) {
+        dlt_daemon_control_service_response(sock, daemon, daemon_local, id, DLT_SERVICE_RESPONSE_PERM_DENIED, verbose);
+        return;
+    }
 
     /* id is always less than DLT_DAEMON_INJECTION_MAX since its type is uinit32_t */
     if (id >= DLT_DAEMON_INJECTION_MIN) {


### PR DESCRIPTION
A new option named "InjectionMode" allows to select if we want to enable / disable the feature.