### PR TITLE
Fix overflow for -d argument in dlt-example-user

### DIFF
--- a/src/examples/dlt-example-user.c
+++ b/src/examples/dlt-example-user.c
@@ -310,9 +310,9 @@ int main(int argc, char *argv[])
         maxnum = 10;
 
     if (dvalue)
-        delay = atoi(dvalue) * 1000000;
+        delay = atoi(dvalue);
     else
-        delay = 500 * 1000000;
+        delay = 500;
 
     if (tvalue)
         dlt_set_resend_timeout_atexit(atoi(tvalue));
@@ -378,8 +378,8 @@ int main(int argc, char *argv[])
         }
 
         if (delay > 0) {
-            ts.tv_sec = delay / 1000000000;
-            ts.tv_nsec = delay % 1000000000;
+            ts.tv_sec = delay / 1000;
+            ts.tv_nsec = (delay % 1000) * 1000000;
             nanosleep(&ts, NULL);
         }
     }


### PR DESCRIPTION
atoi(dvalue) * 1000000 overflows if given a value >= 2147 when sizeof(int) is 4. (2^31 / 10000000 ~= 2147.48)