### PR TITLE
dlt_common: Fix buffer overflow in dlt_filter_load

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -404,7 +404,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
     while (!feof(handle)) {
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%254s", str1) != 1)
             break;
 
         if (str1[0] == 0)
@@ -419,7 +419,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
 
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%254s", str1) != 1)
             break;
 
         if (str1[0] == 0)


### PR DESCRIPTION
A buffer overflow in the dlt_filter_load function in dlt_common.c in dlt-daemon allows arbitrary code execution via an unsafe usage of fscanf, because it does not limit the number of characters to be read in a format argument.

Fixed: #274

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>