### PR TITLE
Bug-Fix for invalid file descriptor validation and missing timeout in unix socket poll

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -4242,13 +4242,8 @@ DltReturnValue dlt_user_log_check_user_message(void)
     nfd[0].events = POLLIN;
     nfd[0].fd = fd;
 
-#if defined DLT_LIB_USE_UNIX_SOCKET_IPC || defined DLT_LIB_USE_VSOCK_IPC
-    if (fd != DLT_FD_INIT) {
-        ret = poll(nfd, 1, -1);
-#else /* DLT_LIB_USE_FIFO_IPC */
-    if (fd != DLT_FD_INIT && dlt_user.dlt_log_handle > 0) {
-        ret = poll(nfd, 1, DLT_USER_RECEIVE_NDELAY);
-#endif
+    if (fd >= 0) {
+        ret = poll(nfd, 1, 1000);
         if (ret) {
             if (nfd[0].revents & (POLLHUP | POLLNVAL | POLLERR)) {
                 dlt_user.dlt_log_handle = DLT_FD_INIT;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -4243,7 +4243,7 @@ DltReturnValue dlt_user_log_check_user_message(void)
     nfd[0].fd = fd;
 
     if (fd >= 0) {
-        ret = poll(nfd, 1, 1000);
+        ret = poll(nfd, 1, DLT_USER_RECEIVE_MDELAY);
         if (ret) {
             if (nfd[0].revents & (POLLHUP | POLLNVAL | POLLERR)) {
                 dlt_user.dlt_log_handle = DLT_FD_INIT;

--- a/src/lib/dlt_user_cfg.h
+++ b/src/lib/dlt_user_cfg.h
@@ -126,6 +126,9 @@
 /* delay for housekeeper thread (nsec) while receiving messages*/
 #define DLT_USER_RECEIVE_NDELAY (500 * 1000 * 1000)
 
+/* timeout for poll operations in milliseconds*/
+#define DLT_USER_RECEIVE_MDELAY (500)
+
 /* Name of environment variable for local print mode */
 #define DLT_USER_ENV_LOCAL_PRINT_MODE "DLT_LOCAL_PRINT_MODE"
 

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -396,7 +396,7 @@ DltReturnValue dlt_offline_trace_write(DltOfflineTrace *trace,
                                        int size3)
 {
 
-    if (trace->ohandle <= 0)
+    if (trace->ohandle < 0)
         return DLT_RETURN_ERROR;
 
     /* check file size here */
@@ -440,7 +440,7 @@ DltReturnValue dlt_offline_trace_write(DltOfflineTrace *trace,
 DltReturnValue dlt_offline_trace_free(DltOfflineTrace *trace)
 {
 
-    if (trace->ohandle <= 0)
+    if (trace->ohandle < 0)
         return DLT_RETURN_ERROR;
 
     /* close last used log file */

--- a/src/shared/dlt_user_shared.c
+++ b/src/shared/dlt_user_shared.c
@@ -108,7 +108,7 @@ DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2
     struct iovec iov[2];
     uint32_t bytes_written;
 
-    if (handle <= 0)
+    if (handle < 0)
         /* Invalid handle */
         return DLT_RETURN_ERROR;
 
@@ -130,7 +130,7 @@ DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2
     struct iovec iov[3];
     uint32_t bytes_written;
 
-    if (handle <= 0)
+    if (handle < 0)
         /* Invalid handle */
         return DLT_RETURN_ERROR;
 
@@ -145,6 +145,11 @@ DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2
 
     if (bytes_written != (len1 + len2 + len3)) {
         switch (errno) {
+        case ETIMEDOUT:
+        {
+            return DLT_RETURN_PIPE_ERROR;     /* ETIMEDOUT - connect timeout */
+            break;
+        }
         case EBADF:
         {
             return DLT_RETURN_PIPE_ERROR;     /* EBADF - handle not open */


### PR DESCRIPTION
The poll timeout was only set for fifo.
TCP connections require this timeout as well.
Poll receives a timeout in milliseconds.
The given paramter was in nanoseconds.
An additional define adds the delay in miliseconds.

Some functions validated file descriptor to be greater 0.
If a process is started without stdin, stdout and stderr
the first file descriptor allocated by the process will be 0.
This also will be the case if the above mentioned file descriptors
will be closed on purpose.
As 0 is a valid fd, some methods had to be changed to reflect this.


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>



