### PR TITLE
dlt_client_main_loop running in an infinite loop restricts graceful e…

### DIFF
--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -75,6 +75,7 @@
 
 #   include "dlt_types.h"
 #   include "dlt_common.h"
+#include <stdbool.h>
 
 typedef enum
 {
@@ -104,6 +105,7 @@ extern "C" {
 #   endif
 
 void dlt_client_register_message_callback(int (*registerd_callback)(DltMessage *message, void *data));
+void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(void *data));
 
 /**
  * Initialising dlt client structure with a specific port

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -97,10 +97,16 @@
 #include "dlt_client_cfg.h"
 
 static int (*message_callback_function)(DltMessage *message, void *data) = NULL;
+static bool (*fetch_next_message_callback_function)(void *data) = NULL;
 
 void dlt_client_register_message_callback(int (*registerd_callback)(DltMessage *message, void *data))
 {
     message_callback_function = registerd_callback;
+}
+
+void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(void *data))
+{
+    fetch_next_message_callback_function = registerd_callback;
 }
 
 DltReturnValue dlt_client_init_port(DltClient *client, int port, int verbose)
@@ -397,7 +403,8 @@ DltReturnValue dlt_client_main_loop(DltClient *client, void *data, int verbose)
     if (dlt_message_init(&msg, verbose) == DLT_RETURN_ERROR)
         return DLT_RETURN_ERROR;
 
-    while (1) {
+    bool fetch_next_message = true;
+    while (fetch_next_message) {
         /* wait for data from socket or serial connection */
         ret = dlt_receiver_receive(&(client->receiver));
 
@@ -439,6 +446,8 @@ DltReturnValue dlt_client_main_loop(DltClient *client, void *data, int verbose)
             dlt_message_free(&msg, verbose);
             return DLT_RETURN_ERROR;
         }
+        if (fetch_next_message_callback_function)
+          fetch_next_message = (*fetch_next_message_callback_function)(data);
     }
 
     if (dlt_message_free(&msg, verbose) == DLT_RETURN_ERROR)


### PR DESCRIPTION
…xit of

DLT Client code

Issue:
------
dlt_client_main_loop currently uses an infinite loop ("while (1)"). This
creates problems when a DLT client is running in a thread as part of a larger
application. Graceful exit (for example: during object destruction) is not
possible because a thread is running dlt_client_main_loop in the background.

It is also not possible to exit the client, if we want it to fetch only a
pre-decided number of messages.

Solution:
---------
Allow user to define a callback function to check whether the next message
should be fetched.

dlt-test-client.c has a new option to fetch a pre-decided number of messages,
after which the client will exit.