### PR TITLE
Export cmake config file

### DIFF
--- a/automotive-dlt-config.cmake.in
+++ b/automotive-dlt-config.cmake.in
@@ -1,7 +1,7 @@
 #######
 # SPDX license identifier: MPL-2.0
 #
-# Copyright (C) 2011-2021, BMW AG
+# Copyright (C) 2021, Martin Willers <M.Willers@gmx.net>
 #
 # This file is part of GENIVI Project DLT - Diagnostic Log and Trace.
 #

--- a/automotive-dlt-config.cmake.in
+++ b/automotive-dlt-config.cmake.in
@@ -1,0 +1,32 @@
+#######
+# SPDX license identifier: MPL-2.0
+#
+# Copyright (C) 2011-2021, BMW AG
+#
+# This file is part of GENIVI Project DLT - Diagnostic Log and Trace.
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License (MPL), v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# For further information see http://www.genivi.org/.
+#######
+
+# Config file for the Genivi::dlt package.
+
+# This file exports the Genivi::dlt CMake target which should be passed to the
+# target_link_libraries command.
+#
+# In addition, the following variable is defined:
+#   @PROJECT_NAME@_FOUND - TRUE if headers and library were found
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+
+check_required_components(@PROJECT_NAME@)

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -25,6 +25,12 @@ within the standard include directory.
 This example gives an overview of DLT usage inside an application by using a
 minimal code example. Detailed information about the API can be found later in
 this document.
+Please note that the #include statement depends on the means by which you are
+incorporating the DLT library into your project. The `<dlt/dlt.h>` form (i.e.
+with a directory prefix) seen here is necessary when you are using the CMake
+Config file (see below). If you are using pkg-config instead, then this #include
+statement needs to refer to only `<dlt.h>`, due to the way the pkg-config module
+exports the include directory.
 
 ```
 #include <dlt/dlt.h>

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -116,7 +116,7 @@ find_package(PkgConfig)
 pkg_check_modules(DLT REQUIRED automotive-dlt)
 ```
 
-to INCLUDE\_DIRECTORIES (or TARGET\_INCLUDE\_DIRECTORIES), add
+to INCLUDE\_DIRECTORIES (or, since CMake 2.8.11, TARGET\_INCLUDE\_DIRECTORIES), add
 
 ```
 ${DLT_INCLUDE_DIRS}

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -27,7 +27,7 @@ minimal code example. Detailed information about the API can be found later in
 this document.
 
 ```
-#include <dlt.h>
+#include <dlt/dlt.h>
 
 DLT_DECLARE_CONTEXT(ctx); /* declare context */
 
@@ -62,7 +62,48 @@ string. On application cleanup, all DLT contexts, as well as the DLT
 application have to be unregistered.
 
 ### DLT with cmake
-To use DLT with cmake, the following lines are the important ones:
+
+To use DLT with CMake, the recommended way is to use the CMake Config file
+that is being generated as part of installation.
+
+You can thus:
+```
+find_package(automotive-dlt)
+...
+target_link_libraries(myapp PRIVATE Genivi::DLT)
+```
+which lets your project automatically gain all necessary compile and link flags
+needed by libdlt, including the include directories.
+
+The generated CMake Config file follows "Modern CMake" convention and only
+exports an IMPORTED CMake target; it does not set any variables.
+
+### DLT with pkg-config
+
+Alternatively to the CMake integration detailed above, it is also possible
+to use DLT via pkg-config. This can also be done with CMake's PkgConfig
+module as well.
+
+#### PkgConfig usage with "Modern CMake"
+
+Here, you let the PkgConfig module create targets as well; the target's name
+is however determined by the PkgConfig module:
+
+```
+find_package(PkgConfig)
+pkg_check_modules(DLT REQUIRED IMPORTED_TARGET automotive-dlt)
+```
+
+As per "Modern CMake", there are again no variables to be added, but only
+a CMake target to be added to the link libraries:
+
+```
+target_link_libraries(myapp PRIVATE PkgConfig::DLT)
+```
+
+#### PkgConfig usage with "Legacy CMake" (<3.0)
+
+Here, you let the PkgConfig module only create variables, but not targets:
 
 ```
 find_package(PkgConfig)
@@ -78,7 +119,7 @@ ${DLT_INCLUDE_DIRS}
 and to TARGET\_LINK\_LIBRARIES:
 
 ```
-${DLT_LIBRARIES}
+${DLT_LINK_LIBRARIES}
 ```
 
 ### Limitation

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -125,8 +125,8 @@ ${DLT_INCLUDE_DIRS}
 and to TARGET\_LINK\_LIBRARIES:
 
 ```
-${DLT_LINK_LIBRARIES}  (for CMake >= 3.12)
-${DLT_LIBRARIES}       (for CMake < 3.12)
+${DLT_LINK_LIBRARIES}  (preferred, for CMake >= 3.12)
+${DLT_LIBRARIES}       (otherwise)
 ```
 
 The contents of `${DLT_LIBRARIES}` do not include the library's path

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -110,7 +110,7 @@ find_package(PkgConfig)
 pkg_check_modules(DLT REQUIRED automotive-dlt)
 ```
 
-to INCLUDE\_DIRECTORIES, add
+to INCLUDE\_DIRECTORIES (or TARGET\_INCLUDE\_DIRECTORIES), add
 
 ```
 ${DLT_INCLUDE_DIRS}
@@ -119,7 +119,21 @@ ${DLT_INCLUDE_DIRS}
 and to TARGET\_LINK\_LIBRARIES:
 
 ```
-${DLT_LINK_LIBRARIES}
+${DLT_LINK_LIBRARIES}  (for CMake >= 3.12)
+${DLT_LIBRARIES}       (for CMake < 3.12)
+```
+
+The contents of `${DLT_LIBRARIES}` do not include the library's path
+(e.g. `-L/path/to/lib`), so if the library resides in a location that is not
+on the linker's default search path, you'll either have to add that path
+to LINK\_DIRECTORIES:
+```
+link_directories(${DLT_LIBRARY_DIRS})
+```
+or, alternatively, not use `${DLT_LIBRARIES}`, but `${DLT_LDFLAGS}` instead,
+which combines `${DLT_LIBRARIES}` and `${DLT_LIBRARY_DIRS}`:
+```
+target_link_libraries(myapp ${DLT_LDFLAGS})
 ```
 
 ### Limitation

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -60,6 +60,8 @@ else()
 endif()
 
 install(TARGETS dlt
+    EXPORT
+        ${PROJECT_NAME}-targets
     RUNTIME
         DESTINATION bin
         COMPONENT base
@@ -69,3 +71,10 @@ install(TARGETS dlt
     ARCHIVE
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
         COMPONENT base)
+
+# Install *-targets.cmake file
+install(
+    EXPORT ${PROJECT_NAME}-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    NAMESPACE Genivi::
+)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -78,3 +78,20 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
     NAMESPACE Genivi::
 )
+
+# Create *-config.cmake file
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake.in
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    NO_SET_AND_CHECK_MACRO
+)
+
+# Install *-config.cmake file
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -45,7 +45,13 @@ else()
 endif()
 
 target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-target_include_directories(dlt PUBLIC ${PROJECT_SOURCE_DIR}/include/dlt ${PROJECT_BINARY_DIR}/include/dlt)
+
+target_include_directories(dlt
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/dlt>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/dlt>
+        $<INSTALL_INTERFACE:include>
+)
 
 if(WITH_LIB_SHORT_VERSION)
     set_target_properties(dlt PROPERTIES VERSION ${PROJECT_VERSION_MAJOR} SOVERSION ${PROJECT_VERSION_MAJOR})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -59,6 +59,8 @@ else()
     set_target_properties(dlt PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 endif()
 
+add_library(Genivi::dlt ALIAS dlt)
+
 install(TARGETS dlt
     EXPORT
         ${PROJECT_NAME}-targets

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -44,7 +44,7 @@ else()
     message(STATUS "pthread_setname_np API not available on this platform")
 endif()
 
-target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} Threads::Threads)
 
 target_include_directories(dlt
     PUBLIC


### PR DESCRIPTION
Create and install proper CMake *-target.cmake and *-config.cmake files,
for use by other CMake-using projects.
