### PR TITLE
Fix include path in *.pc file

### DIFF
--- a/automotive-dlt.pc.in
+++ b/automotive-dlt.pc.in
@@ -23,5 +23,5 @@ Description: Diagnostic Log and Trace
 Version: @PROJECT_VERSION@
 Requires:
 Libs: -L${libdir} -ldlt -lrt -lpthread @ZLIB_LIBRARY@
-Cflags: -I${includedir}/dlt -DDLT_@PROJECT_VERSION_MAJOR@_@PROJECT_VERSION_MINOR@
+Cflags: -I${includedir} -DDLT_@PROJECT_VERSION_MAJOR@_@PROJECT_VERSION_MINOR@
 


### PR DESCRIPTION
Previously, an application using this library's pkg-config setting for
include directory would get e.g. -I/usr/local/dlt/include/dlt
With that include dir, the application needs to write its #include
statements without any prefix, i.e. "#include "dlt_user.h"

This is considered bad practice for header files of an elaborate
library consisting of multiple header files.
For such libraries, one should write #include statements like
this: #include "dlt/dlt_user.h", i.e. prefix it with a directory.

This commit achieves that. The include directory returned by the
above example is now -I/usr/local/dlt/include

Signed-off-by: Martin Willers <M.Willers@gmx.net>