### PR TITLE
dlt-control-common.c: Fix build failure due to out-of-bound write -We…

### DIFF
--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -671,8 +671,8 @@ DltReturnValue dlt_json_filter_load(DltFilter *filter, const char *filename, int
     struct json_object *j_payload_max;
     enum json_tokener_error jerr;
 
-    char app_id[DLT_ID_SIZE] = "";
-    char context_id[DLT_ID_SIZE] = "";
+    char app_id[DLT_ID_SIZE + 1] = "";
+    char context_id[DLT_ID_SIZE + 1] = "";
     int32_t log_level = 0;
     int32_t payload_max = INT32_MAX;
     int32_t payload_min = 0;


### PR DESCRIPTION
…rror=stringop-truncation

cd /build/dlt-daemon-2.18.7/obj-x86_64-linux-gnu/src/console/logstorage && /usr/bin/cc -DCONFIGURATION_FILES_DIR=\"/etc\" -DDLT_DAEMON_USE_FIFO_IPC -DDLT_LIB_USE_FIFO_IPC -DDLT_NETWORK_TRACE_ENABLE -DDLT_SYSTEMD_ENABLE -DDLT_SYSTEMD_JOURNAL_ENABLE -DDLT_UNIT_TESTS -DDLT_USER_IPC_PATH=\"/tmp\" -DDLT_USE_IPv6 -DEXTENDED_FILTERING -D_GNU_SOURCE -I/build/dlt-daemon-2.18.7 -I/build/dlt-daemon-2.18.7/obj-x86_64-linux-gnu/include/dlt -I/build/dlt-daemon-2.18.7/include/dlt -I/build/dlt-daemon-2.18.7/src/shared -I/build/dlt-daemon-2.18.7/src/core_dump_handler -I/build/dlt-daemon-2.18.7/src/offlinelogstorage -I/build/dlt-daemon-2.18.7/src/lib -I/build/dlt-daemon-2.18.7/src/daemon -I/build/dlt-daemon-2.18.7/src/console -I/build/dlt-daemon-2.18.7/src/gateway -I/build/dlt-daemon-2.18.7/systemd/3rdparty -g -O2 -ffile-prefix-map=/build/dlt-daemon-2.18.7=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2   -Werror -std=gnu99 -Wall -Wextra -Wno-variadic-macros -Wno-strict-aliasing -o CMakeFiles/dlt-logstorage-ctrl.dir/__/dlt-control-common.c.o -c /build/dlt-daemon-2.18.7/src/console/dlt-control-common.c
make[3]: Leaving directory '/build/dlt-daemon-2.18.7/obj-x86_64-linux-gnu'
In file included from /usr/include/string.h:495,
                 from /build/dlt-daemon-2.18.7/src/console/dlt-control-common.c:56:
In function 'strncpy',
    inlined from 'dlt_json_filter_load' at /build/dlt-daemon-2.18.7/src/console/dlt-control-common.c:716:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: '__builtin_strncpy' specified bound 4 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'strncpy',
    inlined from 'dlt_json_filter_load' at /build/dlt-daemon-2.18.7/src/console/dlt-control-common.c:721:13:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: error: '__builtin_strncpy' specified bound 4 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~