### PR TITLE
Extend include path in *.pc file

### DIFF
--- a/automotive-dlt.pc.in
+++ b/automotive-dlt.pc.in
@@ -23,5 +23,5 @@ Description: Diagnostic Log and Trace
 Version: @PROJECT_VERSION@
 Requires:
 Libs: -L${libdir} -ldlt -lrt -lpthread @ZLIB_LIBRARY@
-Cflags: -I${includedir}/dlt -DDLT_@PROJECT_VERSION_MAJOR@_@PROJECT_VERSION_MINOR@
+Cflags: -I${includedir}/dlt -I${includedir} -DDLT_@PROJECT_VERSION_MAJOR@_@PROJECT_VERSION_MINOR@
 

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -28,9 +28,9 @@ this document.
 Please note that the #include statement depends on the means by which you are
 incorporating the DLT library into your project. The `<dlt/dlt.h>` form (i.e.
 with a directory prefix) seen here is necessary when you are using the CMake
-Config file (see below). If you are using pkg-config instead, then this #include
-statement needs to refer to only `<dlt.h>`, due to the way the pkg-config module
-exports the include directory.
+Config file (see below). If you are using pkg-config instead, then for
+backward-compatibility reasons it is also possible to use `#include <dlt.h>`.
+This is not recommended for new code, though.
 
 ```
 #include <dlt/dlt.h>
@@ -74,7 +74,7 @@ that is being generated as part of installation.
 
 You can thus:
 ```
-find_package(automotive-dlt)
+find_package(automotive-dlt REQUIRED)
 ...
 target_link_libraries(myapp PRIVATE Genivi::DLT)
 ```
@@ -82,7 +82,9 @@ which lets your project automatically gain all necessary compile and link flags
 needed by libdlt, including the include directories.
 
 The generated CMake Config file follows "Modern CMake" convention and only
-exports an IMPORTED CMake target; it does not set any variables.
+exports an IMPORTED CMake target; it does not set any variables, except for the
+`automotive-dlt_FOUND` variable that can be used to treat DLT as an optional
+dependency.
 
 ### DLT with pkg-config
 


### PR DESCRIPTION
Previously, an application using this library's pkg-config setting for
include directory would only get e.g. -I/usr/local/dlt/include/dlt
With that include dir, the application needs to write its #include
statements without any prefix, i.e. "#include "dlt_user.h"

This is considered bad practice for header files of an elaborate
library consisting of multiple header files.
For such libraries, one should write #include statements like
this: #include "dlt/dlt_user.h", i.e. prefix it with a directory.

This commit achieves that by letting the pkg-config module also return
the upper-level directory in addition to the previous one.
For instance, the include directive returned by the above example
would now be "-I/usr/local/dlt/include -I/usr/local/dlt".

Closes #318

Signed-off-by: Martin Willers <M.Willers@gmx.net>