### PR TITLE
file-transfer: Abort file transfer if get serial number failed

### DIFF
--- a/include/dlt/dlt_filetransfer.h
+++ b/include/dlt/dlt_filetransfer.h
@@ -52,6 +52,8 @@
 #define DLT_FILETRANSFER_ERROR_INFO_ABOUT -700
 /* ! Error code for dlt_user_log_file_packagesCount */
 #define DLT_FILETRANSFER_ERROR_PACKAGE_COUNT -800
+/* ! Error code for failed get serial number */
+#define DLT_FILETRANSFER_FILE_SERIAL_NUMBER -900
 
 
 /* !Transfer the complete file as several dlt logs. */

--- a/src/lib/dlt_filetransfer.c
+++ b/src/lib/dlt_filetransfer.c
@@ -462,6 +462,7 @@ int dlt_user_log_file_header_alias(DltContext *fileContext, const char *filename
                     DLT_STRING(
                         "dlt_user_log_file_header_alias, Error getting serial number of file:"),
                     DLT_STRING(filename));
+            return DLT_FILETRANSFER_FILE_SERIAL_NUMBER;
         }
 
         uint32_t fsize = getFilesize(filename, &ok);
@@ -633,6 +634,8 @@ int dlt_user_log_file_data(DltContext *fileContext,
                 DLT_LOG(*fileContext, DLT_LOG_ERROR,
                         DLT_STRING("failed to get FileSerialNumber for: "),
                         DLT_STRING(filename));
+                fclose (file);
+                return DLT_FILETRANSFER_FILE_SERIAL_NUMBER;
             }
 
             DLT_LOG(*fileContext, DLT_LOG_INFO,
@@ -661,6 +664,8 @@ int dlt_user_log_file_data(DltContext *fileContext,
                         DLT_LOG(*fileContext, DLT_LOG_ERROR,
                                 DLT_STRING("failed to get FileSerialNumber for: "),
                                 DLT_STRING(filename));
+                        fclose(file);
+                        return DLT_FILETRANSFER_FILE_SERIAL_NUMBER;
                     }
 
                     DLT_LOG(*fileContext, DLT_LOG_INFO,
@@ -705,6 +710,7 @@ int dlt_user_log_file_end(DltContext *fileContext, const char *filename, int del
             DLT_LOG(*fileContext, DLT_LOG_ERROR,
                     DLT_STRING("failed to get FileSerialNumber for: "),
                     DLT_STRING(filename));
+            return DLT_FILETRANSFER_FILE_SERIAL_NUMBER;
         }
 
         DLT_LOG(*fileContext, DLT_LOG_INFO,


### PR DESCRIPTION
If a file is deleted while a file transfer is ongoing,
the file transfer tries to seek through the whole file.
This is due to the fact the the file handle is held open.
getFileSerialNumber is already validating the file
by using stat.
If this call returns a negative value, we know
that a stat to the file is not possible anymore,
therefore further reading can be aborted.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

Alexander Mohr, [alexander.m.mohr@daimler.com](mailto:alexander.m.mohr@daimler.com), Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)