### PR TITLE
libdlt: Add legacy include path in exported CMake config file

### DIFF
--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -24,12 +24,8 @@ within the standard include directory.
 This example gives an overview of DLT usage inside an application by using a
 minimal code example. Detailed information about the API can be found later in
 this document.
-Please note that the #include statement depends on the means by which you are
-incorporating the DLT library into your project. The `<dlt/dlt.h>` form (i.e.
-with a directory prefix) seen here is necessary when you are using the CMake
-Config file (see below). If you are using pkg-config instead, then for
-backward-compatibility reasons it is also possible to use `#include <dlt.h>`.
-This is not recommended for new code, though.
+Please note that for backwards compatibility also the legacy #include statement
+`<dlt.h>` is supported. Using it for new code is not recommended, though.
 
 ```
 #include <dlt/dlt.h>

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(dlt
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/dlt>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/dlt>
         $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/dlt>
 )
 
 if(WITH_LIB_SHORT_VERSION)


### PR DESCRIPTION
Previously the generated .pc file was changed to export an additional include path such that '#include <dlt.h>' and '#include <dlt/dlt.h>' can be used. However the exported CMake config file only supports the latter include statement. Consequently code that uses the other legacy include statement does not compile with the exported CMake config file.

This change fixes this inconsistency. It lets users compile existing code with either the pkg-config .pc file or the CMake config file and avoids code clutter that is currently necessary to make this work.

See also #318, #319.