### PR TITLE
Make the legacy include path a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ option(WITH_DLT_KPI           "Set to ON to build src/kpi binaries"             
 option(WITH_DLT_FATAL_LOG_TRAP "Set to ON to enable DLT_LOG_FATAL trap(trigger segv inside dlt-user library)"    OFF)
 option(WITH_UDP_CONNECTION     "Set to ON to enable dlt UDP multicast SUPPORT"                                   OFF)
 option(WITH_LIB_SHORT_VERSION "Set to ON to build library with only major number in version"                    OFF)
+option(WITH_LEGACY_INCLUDE_PATH "Set to ON to add <prefix>/dlt to include paths for the CMake config file, in addition to only <prefix>"
+   OFF)
 option(WITH_EXTENDED_FILTERING "Set to OFF to build without extended filtering. Using json filter files is only supported for Linux based system with json-c and QNX." OFF)
 
 option(WITH_DLT_DAEMON_VSOCK_IPC "Set to ON to enable VSOCK support in daemon"                                   OFF)
@@ -316,6 +318,7 @@ message(STATUS "DLT_VSOCK_PORT = ${DLT_VSOCK_PORT}")
 message(STATUS "WITH_UDP_CONNECTION = ${WITH_UDP_CONNECTION}")
 message(STATUS "WITH_DLT_QNX_SYSTEM = ${WITH_DLT_QNX_SYSTEM}")
 message(STATUS "WITH_LIB_SHORT_VERSION = ${WITH_LIB_SHORT_VERSION}")
+message(STATUS "WITH_LEGACY_INCLUDE_PATH = ${WITH_LEGACY_INCLUDE_PATH}")
 message(STATUS "WITH_EXTENDED_FILTERING = ${WITH_EXTENDED_FILTERING}")
 message(STATUS "Change a value with: cmake -D<Variable>=<Value>")
 message(STATUS "-------------------------------------------------------------------------------")

--- a/doc/dlt_for_developers.md
+++ b/doc/dlt_for_developers.md
@@ -24,8 +24,6 @@ within the standard include directory.
 This example gives an overview of DLT usage inside an application by using a
 minimal code example. Detailed information about the API can be found later in
 this document.
-Please note that for backwards compatibility also the legacy #include statement
-`<dlt.h>` is supported. Using it for new code is not recommended, though.
 
 ```
 #include <dlt/dlt.h>
@@ -80,6 +78,15 @@ The generated CMake Config file follows "Modern CMake" convention and only
 exports an IMPORTED CMake target; it does not set any variables, except for the
 `automotive-dlt_FOUND` variable that can be used to treat DLT as an optional
 dependency.
+
+The generated CMake config file (which is implicitly being used when you call
+`find_package(automotive-dlt)`) by default only adds the top-level directory
+to the compiler's header search path; this requires that users' #include
+directives are written in the regular form e.g. `<dlt/dlt.h>`. If you want
+to be able to use the legacy form `<dlt.h>` as well (as is always allowed by
+the pkg-config module for backwards compatibility reasons), you can configure
+DLT with the CMake option `-DWITH_LEGACY_INCLUDE_PATH=On` in order to
+achieve that.
 
 ### DLT with pkg-config
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -51,8 +51,14 @@ target_include_directories(dlt
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/dlt>
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/dlt>
         $<INSTALL_INTERFACE:include>
-        $<INSTALL_INTERFACE:include/dlt>
 )
+# With this option set, a legacy include path is added in addition to the regular one.
+if(WITH_LEGACY_INCLUDE_PATH)
+    target_include_directories(dlt
+        PUBLIC
+            $<INSTALL_INTERFACE:include/dlt>
+    )
+endif()
 
 if(WITH_LIB_SHORT_VERSION)
     set_target_properties(dlt PROPERTIES VERSION ${PROJECT_VERSION_MAJOR} SOVERSION ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
Keep the generated CMake config file "clean" in that only `<prefix>/include/` is being added to the compiler's header search path by default. If the legacy include path, i.e. `<prefix>/include/dlt/`, is also to be added, then use the CMake option `-DWITH_LEGACY_INCLUDE_PATH=On`.

See also #327, #319, #318

Signed-off-by: Martin Willers <M.Willers@gmx.net>