### PR TITLE
dlt-daemon: create sockets using "android way"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -29,7 +29,7 @@ cc_defaults {
         "-DDLT_DAEMON_USE_UNIX_SOCKET_IPC",
         "-DDLT_LIB_USE_UNIX_SOCKET_IPC",
         "-DCONFIGURATION_FILES_DIR=\"/vendor/etc\"",
-        "-DDLT_USER_IPC_PATH=\"/data/local/tmp\"",
+        "-DDLT_USER_IPC_PATH=\"/dev/socket\"",
     ] + [
         "-Wno-unused-parameter",
         "-W",

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1436,12 +1436,111 @@ static int dlt_daemon_init_vsock(DltDaemonLocal *daemon_local)
 }
 #endif
 
+#ifdef DLT_DAEMON_USE_UNIX_SOCKET_IPC
+static DltReturnValue dlt_daemon_init_app_socket(DltDaemonLocal *daemon_local)
+{
+    /* socket access permission set to srw-rw-rw- (666) */
+    int mask = S_IXUSR | S_IXGRP | S_IXOTH;
+    DltReturnValue ret = DLT_RETURN_OK;
+    int fd = -1;
+
+    if (daemon_local == NULL) {
+        dlt_vlog(LOG_ERR, "%s: Invalid function parameters\n", __func__);
+        return DLT_RETURN_ERROR;
+    }
+
+#ifdef ANDROID
+    /* on android if we want to use security contexts on Unix sockets,
+     * they should be created by init (see dlt-daemon.rc in src/daemon)
+     * and recovered through the below API */
+    ret = dlt_daemon_unix_android_get_socket(&fd, daemon_local->flags.appSockPath);
+    if (ret < DLT_RETURN_OK) {
+        /* we failed to get app socket created by init.
+         * To avoid blocking users to launch dlt-daemon only through
+         * init on android (e.g: by hand for debugging purpose), try to
+         * create app socket by ourselves */
+        ret = dlt_daemon_unix_socket_open(&fd,
+                                          daemon_local->flags.appSockPath,
+                                          SOCK_STREAM,
+                                          mask);
+    }
+#else
+    ret = dlt_daemon_unix_socket_open(&fd,
+                                      daemon_local->flags.appSockPath,
+                                      SOCK_STREAM,
+                                      mask);
+#endif
+    if (ret == DLT_RETURN_OK) {
+        if (dlt_connection_create(daemon_local,
+                                  &daemon_local->pEvent,
+                                  fd,
+                                  POLLIN,
+                                  DLT_CONNECTION_APP_CONNECT)) {
+            dlt_log(LOG_CRIT, "Could not create connection for app socket.\n");
+            return DLT_RETURN_ERROR;
+        }
+    }
+    else {
+        dlt_log(LOG_CRIT, "Could not create and open app socket.\n");
+        return DLT_RETURN_ERROR;
+    }
+
+    return ret;
+}
+#endif
+
+static DltReturnValue dlt_daemon_initialize_control_socket(DltDaemonLocal *daemon_local)
+{
+    /* socket access permission set to srw-rw---- (660)  */
+    int mask = S_IXUSR | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;
+    DltReturnValue ret = DLT_RETURN_OK;
+    int fd = -1;
+
+    if (daemon_local == NULL) {
+        dlt_vlog(LOG_ERR, "%s: Invalid function parameters\n", __func__);
+        return -1;
+    }
+
+#ifdef ANDROID
+    /* on android if we want to use security contexts on Unix sockets,
+     * they should be created by init (see dlt-daemon.rc in src/daemon)
+     * and recovered through the below API */
+    ret = dlt_daemon_unix_android_get_socket(&fd, daemon_local->flags.ctrlSockPath);
+    if (ret < DLT_RETURN_OK) {
+        /* we failed to get app socket created by init.
+         * To avoid blocking users to launch dlt-daemon only through
+         * init on android (e.g by hand for debugging purpose), try to
+         * create app socket by ourselves */
+        ret = dlt_daemon_unix_socket_open(&fd,
+                                          daemon_local->flags.ctrlSockPath,
+                                          SOCK_STREAM,
+                                          mask);
+    }
+#else
+    ret = dlt_daemon_unix_socket_open(&fd,
+                                      daemon_local->flags.ctrlSockPath,
+                                      SOCK_STREAM,
+                                      mask);
+#endif
+    if (ret == DLT_RETURN_OK) {
+        if (dlt_connection_create(daemon_local,
+                                  &daemon_local->pEvent,
+                                  fd,
+                                  POLLIN,
+                                  DLT_CONNECTION_CONTROL_CONNECT) < DLT_RETURN_OK) {
+            dlt_log(LOG_ERR, "Could not initialize control socket.\n");
+            ret = DLT_RETURN_ERROR;
+        }
+    }
+
+    return ret;
+}
+
 int dlt_daemon_local_connection_init(DltDaemon *daemon,
                                      DltDaemonLocal *daemon_local,
                                      int verbose)
 {
     int fd = -1;
-    int mask = 0;
 
     PRINT_FUNCTION_VERBOSE(verbose);
 
@@ -1453,25 +1552,9 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
     DltBindAddress_t *head = daemon_local->flags.ipNodes;
 
 #ifdef DLT_DAEMON_USE_UNIX_SOCKET_IPC
-    /* create and open socket to receive incoming connections from user application
-     * socket access permission set to srw-rw-rw- (666) */
-    mask = S_IXUSR | S_IXGRP | S_IXOTH;
-
-    if (dlt_daemon_unix_socket_open(&fd,
-                                    daemon_local->flags.appSockPath,
-                                    SOCK_STREAM,
-                                    mask) == DLT_RETURN_OK) {
-        if (dlt_connection_create(daemon_local,
-                                  &daemon_local->pEvent,
-                                  fd,
-                                  POLLIN,
-                                  DLT_CONNECTION_APP_CONNECT)) {
-            dlt_log(LOG_CRIT, "Could not initialize app socket.\n");
-            return DLT_RETURN_ERROR;
-        }
-    }
-    else {
-        dlt_log(LOG_CRIT, "Could not initialize app socket.\n");
+    /* create and open socket to receive incoming connections from user application */
+    if (dlt_daemon_init_app_socket(daemon_local) < DLT_RETURN_OK) {
+        dlt_log(LOG_ERR, "Unable to initialize app socket.\n");
         return DLT_RETURN_ERROR;
     }
 
@@ -1548,24 +1631,8 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
 #endif
 
     /* create and open unix socket to receive incoming connections from
-     * control application
-     * socket access permission set to srw-rw---- (660)  */
-    mask = S_IXUSR | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;
-
-    if (dlt_daemon_unix_socket_open(&fd,
-                                    daemon_local->flags.ctrlSockPath,
-                                    SOCK_STREAM,
-                                    mask) == DLT_RETURN_OK) {
-        if (dlt_connection_create(daemon_local,
-                                  &daemon_local->pEvent,
-                                  fd,
-                                  POLLIN,
-                                  DLT_CONNECTION_CONTROL_CONNECT)) {
-            dlt_log(LOG_ERR, "Could not initialize control socket.\n");
-            return DLT_RETURN_ERROR;
-        }
-    }
-    else {
+     * control application */
+    if (dlt_daemon_initialize_control_socket(daemon_local) < DLT_RETURN_OK) {
         dlt_log(LOG_ERR, "Could not initialize control socket.\n");
         return DLT_RETURN_ERROR;
     }

--- a/src/daemon/dlt-daemon.rc
+++ b/src/daemon/dlt-daemon.rc
@@ -2,4 +2,6 @@ service dlt-daemon /vendor/bin/dlt-daemon
     class late_start
     user root
     group root
+    socket dlt stream 666 root root
+    socket dlt-ctrl.sock stream 660 root root
     disabled

--- a/src/daemon/dlt_daemon_unix_socket.h
+++ b/src/daemon/dlt_daemon_unix_socket.h
@@ -56,6 +56,9 @@
 #ifndef DLT_DAEMON_UNIX_SOCKET_H
 #define DLT_DAEMON_UNIX_SOCKET_H
 
+#ifdef ANDROID
+DltReturnValue dlt_daemon_unix_android_get_socket(int *sock, const char *sock_path);
+#endif
 int dlt_daemon_unix_socket_open(int *sock, char *socket_path, int type, int mask);
 int dlt_daemon_unix_socket_close(int sock);
 


### PR DESCRIPTION
# Summary
The goal of this PR is to use the android way to create sockets inside DLT daemon for android system to allow a better configuration of SELinux labels / contexts on them.

# Description
* Before this PR, dlt-daemon sockets were created inside /data/local/tmp. This works but have many drawbacks:
    - /data/local/tmp isn't always a tmpfs depending of the android system you have. Means sockets are potentially created on a  filesystem which binds to a real device
    - as the sockets are created by the dlt-daemon itself, this prevent the usage of specific SELinux labels / contexts as they will inherit the label / context from its parent location (e.g the ones from /data/local/tmp). This prevent a fine control of the SELinux label / context that you would like to apply on them

* This commit adapts the dlt-daemon in such way: 
    - application and control sockets are now created inside /dev/socket which is the standard path for sockets on android
    - these sockets are now created by init (see dlt-daemon.rc) and their fds are recovered by dlt-daemon through a specific android API (dlt_daemon_unix_android_get_socket). If the fds can't be recovered, we fallback to the previous mechanism by creating by ourself the sockets (even if this will prevent SELinux label / context on this socket)
    - all these modifications have been put under compilation flag for android

Signed-off-by: Sebastien RAILLET <sebastien.raillet@marelli.com>